### PR TITLE
Fix Trophy renderer causing render incompatibility #106

### DIFF
--- a/src/main/java/twilightforest/client/TFClientEvents.java
+++ b/src/main/java/twilightforest/client/TFClientEvents.java
@@ -376,15 +376,10 @@ public class TFClientEvents {
 		ItemStack stack = entity.getItemBySlot(EquipmentSlot.HEAD);
 		boolean visible = !(stack.getItem() instanceof TrophyItem) && !(stack.getItem() instanceof SkullCandleItem) && !areCuriosEquipped(entity);
 
-		if (visible) {
-			// Default state is visible, additional visibility setting causes conflict
-			return;
-		} else {
-			if (renderer.getModel() instanceof HeadedModel headedModel) {
-				headedModel.getHead().visible = false;
-				if (renderer.getModel() instanceof HumanoidModel<?> humanoidModel) {
-					humanoidModel.hat.visible = false;
-				}
+		if (!visible && renderer.getModel() instanceof HeadedModel headedModel) {
+			headedModel.getHead().visible = false;
+			if (renderer.getModel() instanceof HumanoidModel<?> humanoidModel) {
+				humanoidModel.hat.visible = false;
 			}
 		}
 	}

--- a/src/main/java/twilightforest/client/TFClientEvents.java
+++ b/src/main/java/twilightforest/client/TFClientEvents.java
@@ -376,10 +376,15 @@ public class TFClientEvents {
 		ItemStack stack = entity.getItemBySlot(EquipmentSlot.HEAD);
 		boolean visible = !(stack.getItem() instanceof TrophyItem) && !(stack.getItem() instanceof SkullCandleItem) && !areCuriosEquipped(entity);
 
-		if (renderer.getModel() instanceof HeadedModel headedModel) {
-			headedModel.getHead().visible = visible;
-			if (renderer.getModel() instanceof HumanoidModel<?> humanoidModel) {
-				humanoidModel.hat.visible = visible && partShown(entity);
+		if (visible) {
+			// Default state is visible, additional visibility setting causes conflict
+			return;
+		} else {
+			if (renderer.getModel() instanceof HeadedModel headedModel) {
+				headedModel.getHead().visible = false;
+				if (renderer.getModel() instanceof HumanoidModel<?> humanoidModel) {
+					humanoidModel.hat.visible = false;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes the following render compatibility issue: https://github.com/TeamTwilight/twilightforest-fabric/issues/106

Equiping and unequiping trophies on the head slot still renders correctly.

![Screenshot 2022-07-29 at 15 45 50](https://user-images.githubusercontent.com/4989469/181774552-bc377dc7-b784-4c49-82f1-c0bbc4bb5602.png)
![Screenshot 2022-07-29 at 15 45 43](https://user-images.githubusercontent.com/4989469/181774535-fe501b34-1da8-4f3a-8aa8-21b8357e0913.png)
