### PR TITLE
Fix lich not moving in the third phase and boss bar color (#246)

### DIFF
--- a/src/main/java/twilightforest/entity/ai/goal/LichPopMobsGoal.java
+++ b/src/main/java/twilightforest/entity/ai/goal/LichPopMobsGoal.java
@@ -44,12 +44,14 @@ public class LichPopMobsGoal extends Goal {
 
 	@Override
 	public boolean canUse() {
-		return !this.lich.isShadowClone() &&
+		boolean result = !this.lich.isShadowClone() &&
 			this.lich.getHealth() < this.lich.getMaxHealth() &&
 			this.lich.getPopCooldown() == 0 &&
 			!this.lich.level().getEntitiesOfClass(Mob.class,
 				this.lich.getBoundingBox().inflate(32.0D, 16.0D, 32.0D),
 				e -> e.getType().is(EntityTagGenerator.LICH_POPPABLES) && this.lich.hasLineOfSight(e)).isEmpty();
+		// Phase 3 is the melee phase; absorbing nearby mobs would stall the Lich's melee AI
+		return result && this.lich.getPhase() < 3;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/entity/boss/Lich.java
+++ b/src/main/java/twilightforest/entity/boss/Lich.java
@@ -1055,11 +1055,7 @@ public class Lich extends BaseTFBoss {
 		int phase = this.getPhase();
 		if (phase == 1) this.getBossBar().setProgress((float) (this.getShieldStrength()) / (float) (this.getAttributeValue(TFAttributes.SHIELD_STRENGTH)));
 		else this.getBossBar().setProgress(this.getHealth() / this.getMaxHealth());
-		if (phase != this.previousPhase) {
-			this.getBossBar().setColor(getBossBarNamedColor());
-			this.getBossBar().setOverlay(this.getBossBarOverlay());
-			this.getBossBar().setDarkenScreen(this.previousPhase != 1);
-		}
+		if (phase != this.previousPhase) this.getBossBar().updateStyle(this.getBossBarColor(), this.getBossBarOverlay(), this.previousPhase != 1);
 		this.previousPhase = phase;
 	}
 
@@ -1073,11 +1069,6 @@ public class Lich extends BaseTFBoss {
 	public int getBossBarColor() {
 		if (this.getShieldStrength() > 0) return 0xFFD800;
 		return this.getPhase() == 2 ? 0xBE23FF : 0xFF0000;
-	}
-
-	private BossEvent.BossBarColor getBossBarNamedColor() {
-		if (this.getShieldStrength() > 0) return BossEvent.BossBarColor.YELLOW;
-		return this.getPhase() == 2 ? BossEvent.BossBarColor.PURPLE : BossEvent.BossBarColor.RED;
 	}
 
 	@Override

--- a/src/main/resources/twilightforest.mixins.json
+++ b/src/main/resources/twilightforest.mixins.json
@@ -46,6 +46,7 @@
     "SnowyDirtBlockMixin",
     "StructureStartMixin",
     "UtilMixin",
+    "WalkNodeEvaluatorMixin",
     "WoodTypeAccessor",
     "WrittenBookItemMixin"
   ],
@@ -65,8 +66,7 @@
     "MinecraftMixin",
     "ModelBakeryMixin",
     "ShaderInstanceMixin",
-    "SplashRendererMixin",
-    "WalkNodeEvaluatorMixin"
+    "SplashRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
- Move WalkNodeEvaluatorMixin from the client list to the common mixins list so pathfinding fixes (banisters -> FENCE, fire jets, hedges, thorns) apply on dedicated servers. Without this, mobs tried to path through banisters in the lich arena and got stuck in the middle of it.
- Use ServerTFBossBar.updateStyle() in Lich#tickBossBar instead of the vanilla setColor/setOverlay/setDarkenScreen calls, which never updated the custom boss bar color on the client, matching the upstream NeoForge implementation.
- Restrict LichPopMobsGoal to phases 1 and 2; in phase 3 it blocked MeleeAttackGoal from starting (higher priority), leaving the Lich standing still and refusing to attack.

Related issue: https://github.com/TeamTwilight/twilightforest-fabric/issues/246