### PR TITLE
Replace javax.annotation.Nullable with org.jspecify in client classes

### DIFF
--- a/src/main/java/twilightforest/client/properties/PotionFlaskTintSource.java
+++ b/src/main/java/twilightforest/client/properties/PotionFlaskTintSource.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import twilightforest.components.item.PotionFlaskComponent;
 import twilightforest.init.TFDataComponents;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record PotionFlaskTintSource(int defaultColor) implements ItemTintSource {
 	public static final MapCodec<PotionFlaskTintSource> TYPE = RecordCodecBuilder.mapCodec(instance -> instance.group(

--- a/src/main/java/twilightforest/client/renderer/entity/MagicPaintingRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/entity/MagicPaintingRenderer.java
@@ -32,7 +32,7 @@ import twilightforest.entity.MagicPaintingVariant;
 import twilightforest.entity.MagicPaintingVariant.Layer.OpacityModifier;
 import twilightforest.entity.MagicPaintingVariant.Layer.Parallax;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class MagicPaintingRenderer extends EntityRenderer<MagicPainting, MagicPaintingRenderState> {
 

--- a/src/main/java/twilightforest/client/state/entity/MagicPaintingRenderState.java
+++ b/src/main/java/twilightforest/client/state/entity/MagicPaintingRenderState.java
@@ -6,7 +6,7 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.world.phys.Vec3;
 import twilightforest.entity.MagicPaintingVariant;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class MagicPaintingRenderState extends EntityRenderState {
 	public Direction direction = Direction.NORTH;

--- a/src/main/java/twilightforest/client/state/entity/PartEntityState.java
+++ b/src/main/java/twilightforest/client/state/entity/PartEntityState.java
@@ -3,7 +3,7 @@ package twilightforest.client.state.entity;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.Component;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class PartEntityState extends EntityRenderState {
 	public float yRot;


### PR DESCRIPTION
javax.annotation is no longer available on JDK 25. Swapped the annotation import for org.jspecify.annotations.Nullable in three client classes:

- PotionFlaskTintSource
- MagicPaintingRenderState
- PartEntityState

Note: MagicPaintingRenderer also uses javax.annotation (fixed) but still fails on state.partialTick, which only exists in NeoForge's EntityRenderState patch; that needs a separate Fabric adaptation.