### PR TITLE
Fix TF particle classes extending vanilla particles with private cons…

### DIFF
--- a/src/main/resources/twilightforest.classtweaker
+++ b/src/main/resources/twilightforest.classtweaker
@@ -265,6 +265,11 @@ accessible method net/minecraft/world/entity/ai/village/poi/PoiTypes register (L
 # FishingHookMixin
 accessible method net/minecraft/world/entity/projectile/Projectile onHit (Lnet/minecraft/world/phys/HitResult;)V
 
+# AngryLichParticle, MagicEffectParticle and ProtectionParticle extend HeartParticle, SpellParticle and SuspendedTownParticle
+accessible method net/minecraft/client/particle/HeartParticle <init> (Lnet/minecraft/client/multiplayer/ClientLevel;DDDLnet/minecraft/client/renderer/texture/TextureAtlasSprite;)V
+accessible method net/minecraft/client/particle/SpellParticle <init> (Lnet/minecraft/client/multiplayer/ClientLevel;DDDDDDLnet/minecraft/client/particle/SpriteSet;)V
+accessible method net/minecraft/client/particle/SuspendedTownParticle <init> (Lnet/minecraft/client/multiplayer/ClientLevel;DDDDDDLnet/minecraft/client/renderer/texture/TextureAtlasSprite;)V
+
 # Enum Extensions
 extend-enum net/minecraft/world/damagesource/DamageEffects TWILIGHTFOREST_PINCH
 extend-enum net/minecraft/world/item/Rarity TWILIGHTFOREST_TWILIGHT


### PR DESCRIPTION
…tructors

MC 26.1 made the constructors of HeartParticle, SpellParticle and SuspendedTownParticle private, which broke the subclasses AngryLichParticle, MagicEffectParticle and ProtectionParticle.

Widened those constructors via the access widener (classtweaker), matching how the project already handles other private Minecraft members.