### PR TITLE
Port TFSkyRenderer to Fabric render state data API

### DIFF
--- a/src/main/java/twilightforest/client/renderer/TFSkyRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/TFSkyRenderer.java
@@ -17,10 +17,10 @@ import net.minecraft.client.renderer.state.level.SkyRenderState;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
-import net.minecraft.util.context.ContextKey;
-import net.neoforged.neoforge.client.event.ExtractLevelRenderStateEvent;
+import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
+import net.fabricmc.fabric.api.client.rendering.v1.level.LevelExtractionContext;
 import org.joml.*;
-import twilightforest.TwilightForestMod;
+import twilightforest.TFMain;
 
 import java.lang.Math;
 import java.util.Optional;
@@ -29,7 +29,7 @@ import java.util.OptionalInt;
 
 public class TFSkyRenderer implements AutoCloseable {
 
-	public static final ContextKey<Boolean> RENDER_DARK_DISC = new ContextKey<>(TwilightForestMod.prefix("render_dark_disc"));
+	public static final RenderStateDataKey<Boolean> RENDER_DARK_DISC = RenderStateDataKey.create();
 	private final RenderSystem.AutoStorageIndexBuffer starIndices = RenderSystem.getSequentialBuffer(VertexFormat.Mode.QUADS);
 	private final GpuBuffer starBuffer;
 	private int starIndexCount;
@@ -38,8 +38,8 @@ public class TFSkyRenderer implements AutoCloseable {
 		this.starBuffer = buildStars();
 	}
 
-	public static void extractLevelRender(ExtractLevelRenderStateEvent event) {
-		event.getRenderState().setRenderData(RENDER_DARK_DISC, shouldDarkenSky(event.getLevel(), event.getDeltaTracker().getGameTimeDeltaTicks()));
+	public static void extractLevelRender(LevelExtractionContext context) {
+		context.levelState().setData(RENDER_DARK_DISC, shouldDarkenSky(context.level(), context.deltaTracker().getGameTimeDeltaTicks()));
 	}
 
 	// [VanillaCopy] LevelRenderer.addSkyPass's overworld branch, without sun/moon/sunrise/sunset, using our own stars at full brightness, and lowering void horizon threshold height from getHorizonHeight (63) to 0
@@ -69,7 +69,7 @@ public class TFSkyRenderer implements AutoCloseable {
 		renderStars(posestack);
 		posestack.popPose();
 		//TF: use custom height checks for the void sky as vanilla hardcodes to 63
-		if (Boolean.TRUE.equals(level.getRenderData(RENDER_DARK_DISC))) {
+		if (Boolean.TRUE.equals(level.getData(RENDER_DARK_DISC))) {
 			levelRenderer.skyRenderer.renderDarkDisc();
 		}
 

--- a/src/main/java/twilightforest/client/renderer/TFSkyRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/TFSkyRenderer.java
@@ -30,7 +30,7 @@ import java.util.OptionalInt;
 
 public class TFSkyRenderer implements AutoCloseable {
 
-	public static final RenderStateDataKey<Boolean> RENDER_DARK_DISC = RenderStateDataKey.create();
+	public static final RenderStateDataKey<Boolean> RENDER_DARK_DISC = RenderStateDataKey.create(() -> TFMain.prefix("render_dark_disc").toString());
 	private final RenderSystem.AutoStorageIndexBuffer starIndices = RenderSystem.getSequentialBuffer(VertexFormat.Mode.QUADS);
 	private final GpuBuffer starBuffer;
 	private int starIndexCount;

--- a/src/main/java/twilightforest/client/renderer/TFSkyRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/TFSkyRenderer.java
@@ -19,6 +19,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelExtractionContext;
+import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
 import org.joml.*;
 import twilightforest.TFMain;
 
@@ -36,6 +37,10 @@ public class TFSkyRenderer implements AutoCloseable {
 
 	public TFSkyRenderer() {
 		this.starBuffer = buildStars();
+	}
+
+	public static void init() {
+		LevelRenderEvents.END_EXTRACTION.register(TFSkyRenderer::extractLevelRender);
 	}
 
 	public static void extractLevelRender(LevelExtractionContext context) {

--- a/src/main/java/twilightforest/client/renderer/TFSkyRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/TFSkyRenderer.java
@@ -21,7 +21,6 @@ import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelExtractionContext;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
 import org.joml.*;
-import twilightforest.TFMain;
 
 import java.lang.Math;
 import java.util.Optional;
@@ -30,7 +29,7 @@ import java.util.OptionalInt;
 
 public class TFSkyRenderer implements AutoCloseable {
 
-	public static final RenderStateDataKey<Boolean> RENDER_DARK_DISC = RenderStateDataKey.create(() -> TFMain.prefix("render_dark_disc").toString());
+	public static final RenderStateDataKey<Boolean> RENDER_DARK_DISC = RenderStateDataKey.create(() -> "render_dark_disc");
 	private final RenderSystem.AutoStorageIndexBuffer starIndices = RenderSystem.getSequentialBuffer(VertexFormat.Mode.QUADS);
 	private final GpuBuffer starBuffer;
 	private int starIndexCount;


### PR DESCRIPTION
Replaced the NeoForge ExtractLevelRenderStateEvent and its ContextKey-based render data with Fabric equivalents:

- ExtractLevelRenderStateEvent -> LevelExtractionContext (hooked via LevelRenderEvents.END_EXTRACTION later)
- ContextKey + setRenderData/getRenderData -> RenderStateDataKey + FabricRenderState.setData/getData (interface-injected onto LevelRenderState)
- TwilightForestMod.prefix -> TFMain