### PR TITLE
Use Enforcements ResourceKey constants in TFWeatherRenderer

### DIFF
--- a/src/main/java/twilightforest/client/renderer/TFWeatherRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/TFWeatherRenderer.java
@@ -350,11 +350,11 @@ public class TFWeatherRenderer {
 	}
 
 	private static @Nullable TFWeatherRenderer.WeatherRenderType getRenderType(Restriction restriction) {
-		if (restriction.enforcement().equals(Enforcements.FROST.getKey())) return WeatherRenderType.BLIZZARD;
-		else if (restriction.enforcement().equals(Enforcements.HUNGER.getKey())) return WeatherRenderType.MOSQUITO;
-		else if (restriction.enforcement().equals(Enforcements.FIRE.getKey())) return WeatherRenderType.ASHES;
-		else if (restriction.enforcement().equals(Enforcements.DARKNESS.getKey())) return random.nextBoolean() ? WeatherRenderType.DARK_STREAM : null;
-		else if (restriction.enforcement().equals(Enforcements.ACID_RAIN.getKey())) return WeatherRenderType.BIG_RAIN;
+		if (restriction.enforcement().equals(Enforcements.FROST_KEY)) return WeatherRenderType.BLIZZARD;
+		else if (restriction.enforcement().equals(Enforcements.HUNGER_KEY)) return WeatherRenderType.MOSQUITO;
+		else if (restriction.enforcement().equals(Enforcements.FIRE_KEY)) return WeatherRenderType.ASHES;
+		else if (restriction.enforcement().equals(Enforcements.DARKNESS_KEY)) return random.nextBoolean() ? WeatherRenderType.DARK_STREAM : null;
+		else if (restriction.enforcement().equals(Enforcements.ACID_RAIN_KEY)) return WeatherRenderType.BIG_RAIN;
 		return null;
 	}
 


### PR DESCRIPTION
The Fabric Enforcements registry exposes plain Enforcement instances plus dedicated *_KEY ResourceKey constants, so replace the NeoForge-style DeferredHolder.getKey() calls with those constants.