### PR TITLE
Fix special renderers and tooltip compile errors

### DIFF
--- a/src/main/java/twilightforest/client/renderer/special/CandelabraSpecialRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/special/CandelabraSpecialRenderer.java
@@ -5,7 +5,6 @@ import com.mojang.serialization.MapCodec;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
-import net.minecraft.client.renderer.block.BlockModelResolver;
 import net.minecraft.client.renderer.block.model.BlockDisplayContext;
 import net.minecraft.client.renderer.special.SpecialModelRenderer;
 import net.minecraft.core.Direction;
@@ -29,7 +28,7 @@ public record CandelabraSpecialRenderer() implements SpecialModelRenderer<List<B
 		for (int i = 0; i < stack.getOrDefault(TFDataComponents.CANDELABRA_DATA, CandelabraData.EMPTY).ordered().size(); i++) {
 			BlockModelRenderState state = new BlockModelRenderState();
 			BlockState candle = CandelabraData.getItem(stack.getOrDefault(TFDataComponents.CANDELABRA_DATA, CandelabraData.EMPTY).ordered(), i).orElse(Blocks.AIR).defaultBlockState();
-			new BlockModelResolver(Minecraft.getInstance().getModelManager()).update(state, candle, BlockDisplayContext.create());
+			Minecraft.getInstance().blockModelResolver.update(state, candle, BlockDisplayContext.create());
 			models.add(state);
 		}
 

--- a/src/main/java/twilightforest/client/renderer/special/CandelabraSpecialRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/special/CandelabraSpecialRenderer.java
@@ -5,6 +5,7 @@ import com.mojang.serialization.MapCodec;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
+import net.minecraft.client.renderer.block.BlockModelResolver;
 import net.minecraft.client.renderer.block.model.BlockDisplayContext;
 import net.minecraft.client.renderer.special.SpecialModelRenderer;
 import net.minecraft.core.Direction;
@@ -28,7 +29,7 @@ public record CandelabraSpecialRenderer() implements SpecialModelRenderer<List<B
 		for (int i = 0; i < stack.getOrDefault(TFDataComponents.CANDELABRA_DATA, CandelabraData.EMPTY).ordered().size(); i++) {
 			BlockModelRenderState state = new BlockModelRenderState();
 			BlockState candle = CandelabraData.getItem(stack.getOrDefault(TFDataComponents.CANDELABRA_DATA, CandelabraData.EMPTY).ordered(), i).orElse(Blocks.AIR).defaultBlockState();
-			Minecraft.getInstance().getBlockModelResolver().update(state, candle, BlockDisplayContext.create());
+			new BlockModelResolver(Minecraft.getInstance().getModelManager()).update(state, candle, BlockDisplayContext.create());
 			models.add(state);
 		}
 

--- a/src/main/java/twilightforest/client/renderer/special/SkullCandleSpecialRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/special/SkullCandleSpecialRenderer.java
@@ -10,7 +10,6 @@ import net.minecraft.client.model.object.skull.SkullModelBase;
 import net.minecraft.client.renderer.PlayerSkinRenderCache;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
-import net.minecraft.client.renderer.block.BlockModelResolver;
 import net.minecraft.client.renderer.blockentity.SkullBlockRenderer;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.special.SpecialModelRenderer;
@@ -50,7 +49,7 @@ public record SkullCandleSpecialRenderer(PlayerSkinRenderCache playerSkinRenderC
 		if (skullCandles != null) {
 			stack.translate(0.0F, 0.5F, 0.0F);
 			BlockModelRenderState state = new BlockModelRenderState();
-			SkullCandleRenderer.updateSkullCandle(skullCandles, new BlockModelResolver(Minecraft.getInstance().getModelManager()), state, false);
+			SkullCandleRenderer.updateSkullCandle(skullCandles, Minecraft.getInstance().blockModelResolver, state, false);
 			SkullCandleRenderer.submitCandles(state, stack, collector, light, overlay, outlineColor);
 		}
 	}

--- a/src/main/java/twilightforest/client/renderer/special/SkullCandleSpecialRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/special/SkullCandleSpecialRenderer.java
@@ -10,6 +10,7 @@ import net.minecraft.client.model.object.skull.SkullModelBase;
 import net.minecraft.client.renderer.PlayerSkinRenderCache;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
+import net.minecraft.client.renderer.block.BlockModelResolver;
 import net.minecraft.client.renderer.blockentity.SkullBlockRenderer;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.special.SpecialModelRenderer;
@@ -49,7 +50,7 @@ public record SkullCandleSpecialRenderer(PlayerSkinRenderCache playerSkinRenderC
 		if (skullCandles != null) {
 			stack.translate(0.0F, 0.5F, 0.0F);
 			BlockModelRenderState state = new BlockModelRenderState();
-			SkullCandleRenderer.updateSkullCandle(skullCandles, Minecraft.getInstance().getBlockModelResolver(), state, false);
+			SkullCandleRenderer.updateSkullCandle(skullCandles, new BlockModelResolver(Minecraft.getInstance().getModelManager()), state, false);
 			SkullCandleRenderer.submitCandles(state, stack, collector, light, overlay, outlineColor);
 		}
 	}

--- a/src/main/java/twilightforest/client/renderer/tooltip/ItemDisplayTooltipComponent.java
+++ b/src/main/java/twilightforest/client/renderer/tooltip/ItemDisplayTooltipComponent.java
@@ -55,7 +55,7 @@ public class ItemDisplayTooltipComponent implements ClientTooltipComponent {
 
 	private void renderBlankSlot(GuiGraphicsExtractor graphics, int index, int x, int y) {
 		if (index < 0 || index >= ItemDisplayContents.LAYOUT.size()) return;
-		ItemDisplayType type = ItemDisplayContents.LAYOUT.get(index).get();
+		ItemDisplayType type = ItemDisplayContents.LAYOUT.get(index);
 		type.slotTexture().ifPresent(identifier -> graphics.blit(identifier, x + 1, y + 1, 0, 0, 16, 16, 16, 16));
 	}
 


### PR DESCRIPTION
- CandelabraSpecialRenderer and SkullCandleSpecialRenderer: Minecraft has no getBlockModelResolver() getter in 26.1, construct a BlockModelResolver from the model manager instead
- ItemDisplayTooltipComponent: ItemDisplayContents.LAYOUT already holds ItemDisplayType instances, drop the stale NeoForge-style .get()