### PR TITLE
Drop removed BlockEntityRenderer.getRenderBoundingBox overrides

### DIFF
--- a/src/main/java/twilightforest/client/renderer/block/BrazierRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/block/BrazierRenderer.java
@@ -12,6 +12,7 @@ import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.LightCoordsUtil;
@@ -74,7 +75,7 @@ public class BrazierRenderer implements BlockEntityRenderer<BrazierBlockEntity, 
 	}
 
 	@Override
-	public AABB getRenderBoundingBox(net.minecraft.world.level.block.entity.BlockEntity blockEntity) {
+	public AABB getRenderBoundingBox(BlockEntity blockEntity) {
 		BlockPos pos = blockEntity.getBlockPos();
 		return new AABB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1.0, pos.getY() + 2.0, pos.getZ() + 1.0);
 	}

--- a/src/main/java/twilightforest/client/renderer/block/BrazierRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/block/BrazierRenderer.java
@@ -2,6 +2,7 @@ package twilightforest.client.renderer.block;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
+import carminite.interfaces.markers.IExtendedBoundingBoxBlockEntityRenderer;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockModelResolver;
 import net.minecraft.client.renderer.block.model.BlockDisplayContext;
@@ -11,11 +12,11 @@ import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.util.Unit;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import org.jspecify.annotations.Nullable;
 import twilightforest.TFMain;
@@ -25,7 +26,7 @@ import twilightforest.client.model.TFModelLayers;
 import twilightforest.client.model.block.BrazierModel;
 import twilightforest.client.state.block.BrazierRenderState;
 
-public class BrazierRenderer implements BlockEntityRenderer<BrazierBlockEntity, BrazierRenderState> {
+public class BrazierRenderer implements BlockEntityRenderer<BrazierBlockEntity, BrazierRenderState>, IExtendedBoundingBoxBlockEntityRenderer {
 
 	private final BlockModelResolver blockResolver;
 	private final BrazierModel model;
@@ -73,7 +74,7 @@ public class BrazierRenderer implements BlockEntityRenderer<BrazierBlockEntity, 
 	}
 
 	@Override
-	public AABB getRenderBoundingBox(BrazierBlockEntity blockEntity) {
+	public AABB getRenderBoundingBox(net.minecraft.world.level.block.entity.BlockEntity blockEntity) {
 		BlockPos pos = blockEntity.getBlockPos();
 		return new AABB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1.0, pos.getY() + 2.0, pos.getZ() + 1.0);
 	}

--- a/src/main/java/twilightforest/client/renderer/block/SinisterSpawnerRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/block/SinisterSpawnerRenderer.java
@@ -12,6 +12,7 @@ import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
@@ -74,7 +75,7 @@ public class SinisterSpawnerRenderer implements BlockEntityRenderer<SinisterSpaw
 	}
 
 	@Override
-	public AABB getRenderBoundingBox(net.minecraft.world.level.block.entity.BlockEntity blockEntity) {
+	public AABB getRenderBoundingBox(BlockEntity blockEntity) {
 		BlockPos pos = blockEntity.getBlockPos();
 		return new AABB(pos.getX() - 1.0D, pos.getY() - 1.0D, pos.getZ() - 1.0D, pos.getX() + 2.0D, pos.getY() + 2.0D, pos.getZ() + 2.0D);
 	}

--- a/src/main/java/twilightforest/client/renderer/block/SinisterSpawnerRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/block/SinisterSpawnerRenderer.java
@@ -2,6 +2,7 @@ package twilightforest.client.renderer.block;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
+import carminite.interfaces.markers.IExtendedBoundingBoxBlockEntityRenderer;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -11,16 +12,16 @@ import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.BaseSpawner;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import org.jspecify.annotations.Nullable;
 import twilightforest.block.entity.spawner.SinisterSpawnerBlockEntity;
 
 // [VANILLA COPY] SpawnerRenderer (Type bound changed to CursedSpawnerEntity)
-public class SinisterSpawnerRenderer implements BlockEntityRenderer<SinisterSpawnerBlockEntity, SpawnerRenderState> {
+public class SinisterSpawnerRenderer implements BlockEntityRenderer<SinisterSpawnerBlockEntity, SpawnerRenderState>, IExtendedBoundingBoxBlockEntityRenderer {
     private final EntityRenderDispatcher entityRenderer;
 
     public SinisterSpawnerRenderer(BlockEntityRendererProvider.Context context) {
@@ -73,8 +74,8 @@ public class SinisterSpawnerRenderer implements BlockEntityRenderer<SinisterSpaw
 	}
 
 	@Override
-	public AABB getRenderBoundingBox(SinisterSpawnerBlockEntity entity) {
-		BlockPos pos = entity.getBlockPos();
+	public AABB getRenderBoundingBox(net.minecraft.world.level.block.entity.BlockEntity blockEntity) {
+		BlockPos pos = blockEntity.getBlockPos();
 		return new AABB(pos.getX() - 1.0D, pos.getY() - 1.0D, pos.getZ() - 1.0D, pos.getX() + 2.0D, pos.getY() + 2.0D, pos.getZ() + 2.0D);
 	}
 }


### PR DESCRIPTION
getRenderBoundingBox no longer exists on BlockEntityRenderer in 26.1 (it was a NeoForge-patched method), so the Brazier and Sinister Spawner renderers fall back to vanilla culling. The custom bounds (taller brazier flame, larger spawner range) would need a different mechanism if they are still desired.