### PR TITLE
Port MovingCicadaSoundInstance to Fabric

### DIFF
--- a/src/main/java/twilightforest/client/MovingCicadaSoundInstance.java
+++ b/src/main/java/twilightforest/client/MovingCicadaSoundInstance.java
@@ -5,8 +5,6 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.fml.ModList;
-import twilightforest.compat.curios.CuriosCompat;
 import twilightforest.config.TFConfig;
 import twilightforest.init.TFBlocks;
 import twilightforest.init.TFSounds;
@@ -16,7 +14,7 @@ public class MovingCicadaSoundInstance extends AbstractTickableSoundInstance {
 	protected final LivingEntity wearer;
 
 	public MovingCicadaSoundInstance(LivingEntity entity) {
-		super(TFSounds.CICADA.get(), SoundSource.NEUTRAL, SoundInstance.createUnseededRandom());
+		super(TFSounds.CICADA.value(), SoundSource.NEUTRAL, SoundInstance.createUnseededRandom());
 		this.wearer = entity;
 		this.x = entity.getX();
 		this.y = entity.getY();
@@ -27,20 +25,13 @@ public class MovingCicadaSoundInstance extends AbstractTickableSoundInstance {
 
 	@Override
 	public void tick() {
-		if (!this.wearer.isRemoved() && (this.wearer.getItemBySlot(EquipmentSlot.HEAD).is(TFBlocks.CICADA.asItem()) || this.isWearingCicadaCurio())) {
+		if (!this.wearer.isRemoved() && this.wearer.getItemBySlot(EquipmentSlot.HEAD).is(TFBlocks.CICADA.asItem())) {
 			this.x = (float) this.wearer.getX();
 			this.y = (float) this.wearer.getY();
 			this.z = (float) this.wearer.getZ();
 		} else {
 			this.stop();
 		}
-	}
-
-	private boolean isWearingCicadaCurio() {
-		if (ModList.get().isLoaded("curios")) {
-			return CuriosCompat.isCurioEquipped(this.wearer, stack -> stack.is(TFBlocks.CICADA.asItem()));
-		}
-		return false;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/client/MovingCicadaSoundInstance.java
+++ b/src/main/java/twilightforest/client/MovingCicadaSoundInstance.java
@@ -1,5 +1,6 @@
 package twilightforest.client;
 
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.resources.sounds.AbstractTickableSoundInstance;
 import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.sounds.SoundSource;
@@ -25,13 +26,20 @@ public class MovingCicadaSoundInstance extends AbstractTickableSoundInstance {
 
 	@Override
 	public void tick() {
-		if (!this.wearer.isRemoved() && this.wearer.getItemBySlot(EquipmentSlot.HEAD).is(TFBlocks.CICADA.asItem())) {
+		if (!this.wearer.isRemoved() && (this.wearer.getItemBySlot(EquipmentSlot.HEAD).is(TFBlocks.CICADA.asItem()) || this.isWearingCicadaTrinket())) {
 			this.x = (float) this.wearer.getX();
 			this.y = (float) this.wearer.getY();
 			this.z = (float) this.wearer.getZ();
 		} else {
 			this.stop();
 		}
+	}
+
+	private boolean isWearingCicadaTrinket() {
+		if (FabricLoader.getInstance().isModLoaded("trinkets")) {
+			//return CuriosCompat.isCurioEquipped(this.wearer, stack -> stack.is(TFBlocks.CICADA.asItem()));
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
- Drop the Curios check (twilightforest.compat.curios does not exist on Fabric yet), keeping the head-slot cicada sound behaviour
- Drop the NeoForge ModList import
- Use TFSounds.CICADA.value() since TFSounds.CICADA is a Holder now