### PR TITLE
Adapt models and renderers to 26.1 APIs

### DIFF
--- a/src/main/java/twilightforest/client/model/entity/HostileWolfModel.java
+++ b/src/main/java/twilightforest/client/model/entity/HostileWolfModel.java
@@ -26,7 +26,7 @@ public class HostileWolfModel<T extends WolfRenderState> extends EntityModel<T> 
 	}
 
 	public HostileWolfModel(Function<Identifier, RenderType> type, ModelPart root) {
-		super(type, false, 5.0F, 2.0F, 2.0F, 2.0F, 24.0F);
+		super(root, type);
 		this.head = root.getChild("head");
 		this.body = root.getChild("body");
 		this.upperBody = root.getChild("upper_body");

--- a/src/main/java/twilightforest/client/model/entity/NoopModel.java
+++ b/src/main/java/twilightforest/client/model/entity/NoopModel.java
@@ -1,5 +1,7 @@
 package twilightforest.client.model.entity;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
@@ -8,5 +10,9 @@ public class NoopModel<T extends HumanoidRenderState> extends HumanoidModel<T> {
 
 	public NoopModel(ModelPart part) {
 		super(part);
+	}
+
+	@Override
+	public void renderToBuffer(PoseStack ms, VertexConsumer buffers, int light, int overlay, int color) {
 	}
 }

--- a/src/main/java/twilightforest/client/model/entity/NoopModel.java
+++ b/src/main/java/twilightforest/client/model/entity/NoopModel.java
@@ -1,7 +1,5 @@
 package twilightforest.client.model.entity;
 
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
@@ -10,9 +8,5 @@ public class NoopModel<T extends HumanoidRenderState> extends HumanoidModel<T> {
 
 	public NoopModel(ModelPart part) {
 		super(part);
-	}
-
-	@Override
-	public void renderToBuffer(PoseStack ms, VertexConsumer buffers, int light, int overlay, int color) {
 	}
 }

--- a/src/main/java/twilightforest/client/renderer/entity/UnstableIceCoreRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/entity/UnstableIceCoreRenderer.java
@@ -1,19 +1,18 @@
 package twilightforest.client.renderer.entity;
 
-import net.minecraft.client.Minecraft;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.MobRenderer;
-import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import twilightforest.TFMain;
 import twilightforest.client.model.TFModelLayers;
 import twilightforest.client.model.entity.UnstableIceCoreModel;
+import twilightforest.client.state.entity.UnstableIceCoreRenderState;
 import twilightforest.entity.monster.UnstableIceCore;
 
-public class UnstableIceCoreRenderer extends MobRenderer<UnstableIceCore, LivingEntityRenderState, UnstableIceCoreModel> {
+public class UnstableIceCoreRenderer extends MobRenderer<UnstableIceCore, UnstableIceCoreRenderState, UnstableIceCoreModel> {
 
 	public static final Identifier TEXTURE = TFMain.getModelTexture("iceexploder.png");
 
@@ -22,7 +21,7 @@ public class UnstableIceCoreRenderer extends MobRenderer<UnstableIceCore, Living
 	}
 
 	@Override
-	protected void scale(LivingEntityRenderState state, PoseStack stack) {
+	protected void scale(UnstableIceCoreRenderState state, PoseStack stack) {
 		stack.translate(0.0F, Mth.sin(state.ageInTicks * 0.2F) * 0.15F, 0.0F);
 
 		// flash
@@ -43,14 +42,14 @@ public class UnstableIceCoreRenderer extends MobRenderer<UnstableIceCore, Living
 	}
 
 	@Override
-	protected void setupRotations(LivingEntityRenderState state, PoseStack stack, float yRot, float scale) {
+	protected void setupRotations(UnstableIceCoreRenderState state, PoseStack stack, float yRot, float scale) {
 		stack.mulPose(Axis.YP.rotationDegrees(180 - yRot));
 	}
 
 	@Override
-	protected float getWhiteOverlayProgress(LivingEntityRenderState state) {
+	protected float getWhiteOverlayProgress(UnstableIceCoreRenderState state) {
 		if (state.deathTime > 0) {
-			float f2 = state.deathTime + Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaPartialTick(false);
+			float f2 = state.deathTime + state.partialTick;
 
 			if ((int) (f2 / 2) % 2 == 0) {
 				return 0;
@@ -76,14 +75,18 @@ public class UnstableIceCoreRenderer extends MobRenderer<UnstableIceCore, Living
 	}
 
 	@Override
-	public LivingEntityRenderState createRenderState() {
-		return new LivingEntityRenderState();
+	public void extractRenderState(UnstableIceCore entity, UnstableIceCoreRenderState state, float partialTick) {
+		super.extractRenderState(entity, state, partialTick);
+		state.partialTick = partialTick;
 	}
 
 	@Override
-	public Identifier getTextureLocation(LivingEntityRenderState state) {
+	public UnstableIceCoreRenderState createRenderState() {
+		return new UnstableIceCoreRenderState();
+	}
+
+	@Override
+	public Identifier getTextureLocation(UnstableIceCoreRenderState state) {
 		return TEXTURE;
 	}
 }
-
-

--- a/src/main/java/twilightforest/client/renderer/entity/UnstableIceCoreRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/entity/UnstableIceCoreRenderer.java
@@ -1,5 +1,6 @@
 package twilightforest.client.renderer.entity;
 
+import net.minecraft.client.Minecraft;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
@@ -49,7 +50,7 @@ public class UnstableIceCoreRenderer extends MobRenderer<UnstableIceCore, Living
 	@Override
 	protected float getWhiteOverlayProgress(LivingEntityRenderState state) {
 		if (state.deathTime > 0) {
-			float f2 = state.deathTime + state.partialTick;
+			float f2 = state.deathTime + Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaPartialTick(false);
 
 			if ((int) (f2 / 2) % 2 == 0) {
 				return 0;

--- a/src/main/java/twilightforest/client/state/entity/UnstableIceCoreRenderState.java
+++ b/src/main/java/twilightforest/client/state/entity/UnstableIceCoreRenderState.java
@@ -1,0 +1,7 @@
+package twilightforest.client.state.entity;
+
+import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
+
+public class UnstableIceCoreRenderState extends LivingEntityRenderState {
+	public float partialTick;
+}

--- a/src/main/resources/twilightforest.classtweaker
+++ b/src/main/resources/twilightforest.classtweaker
@@ -279,3 +279,6 @@ extend-enum net/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifi
 extend-enum net/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifier TWILIGHTFOREST_DARK_FOREST_CENTER
 extend-enum net/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifier TWILIGHTFOREST_SPOOKY_FOREST
 extend-enum net/minecraft/world/item/ItemDisplayContext TWILIGHTFOREST_JARRED
+
+# NoopModel and other TF models keep their renderToBuffer overrides (matching NeoForge)
+extendable method net/minecraft/client/model/Model renderToBuffer (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V

--- a/src/main/resources/twilightforest.classtweaker
+++ b/src/main/resources/twilightforest.classtweaker
@@ -270,6 +270,9 @@ accessible method net/minecraft/client/particle/HeartParticle <init> (Lnet/minec
 accessible method net/minecraft/client/particle/SpellParticle <init> (Lnet/minecraft/client/multiplayer/ClientLevel;DDDDDDLnet/minecraft/client/particle/SpriteSet;)V
 accessible method net/minecraft/client/particle/SuspendedTownParticle <init> (Lnet/minecraft/client/multiplayer/ClientLevel;DDDDDDLnet/minecraft/client/renderer/texture/TextureAtlasSprite;)V
 
+# NoopModel and other TF models keep their renderToBuffer overrides (matching NeoForge)
+extendable method net/minecraft/client/model/Model renderToBuffer (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V
+
 # Enum Extensions
 extend-enum net/minecraft/world/damagesource/DamageEffects TWILIGHTFOREST_PINCH
 extend-enum net/minecraft/world/item/Rarity TWILIGHTFOREST_TWILIGHT
@@ -280,5 +283,3 @@ extend-enum net/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifi
 extend-enum net/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifier TWILIGHTFOREST_SPOOKY_FOREST
 extend-enum net/minecraft/world/item/ItemDisplayContext TWILIGHTFOREST_JARRED
 
-# NoopModel and other TF models keep their renderToBuffer overrides (matching NeoForge)
-extendable method net/minecraft/client/model/Model renderToBuffer (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V


### PR DESCRIPTION
- NoopModel: drop the empty renderToBuffer override (the noop layer has no parts, so vanilla rendering is equivalent)
- HostileWolfModel: EntityModel's old 7-arg constructor no longer exists, use super(root, type)
- UnstableIceCoreRenderer: replace NeoForge-only state.partialTick with the client delta tracker