### PR TITLE
Fix more client compile errors

### DIFF
--- a/src/main/java/twilightforest/client/renderer/block/SkullChestRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/block/SkullChestRenderer.java
@@ -15,7 +15,7 @@ import net.minecraft.world.level.block.entity.LidBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import org.jspecify.annotations.Nullable;
-import twilightforest.TwilightForestMod;
+import twilightforest.TFMain;
 import twilightforest.block.SkullChestBlock;
 import twilightforest.client.model.TFModelLayers;
 import twilightforest.client.model.entity.KeepsakeCasketModel;
@@ -23,7 +23,7 @@ import twilightforest.client.state.block.SkullChestRenderState;
 
 public class SkullChestRenderer<T extends BlockEntity & LidBlockEntity> implements BlockEntityRenderer<T, SkullChestRenderState> {
 
-	public static final Identifier SKULL_CHEST_TEXTURE = TwilightForestMod.getModelTexture("casket/skull_chest.png");
+	public static final Identifier SKULL_CHEST_TEXTURE = TFMain.getModelTexture("casket/skull_chest.png");
 
 	private final KeepsakeCasketModel model;
 

--- a/src/main/java/twilightforest/client/renderer/entity/layers/IceLayer.java
+++ b/src/main/java/twilightforest/client/renderer/entity/layers/IceLayer.java
@@ -13,17 +13,16 @@ import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
-import net.minecraft.util.context.ContextKey;
 import net.minecraft.world.level.block.Blocks;
-import twilightforest.TFMain;
+import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
 import twilightforest.client.model.entity.DeathTomeModel;
 import twilightforest.potions.FrostedEffect;
 
 public class IceLayer<S extends LivingEntityRenderState, M extends EntityModel<S>> extends RenderLayer<S, M> {
 	private final RandomSource random = RandomSource.create();
 
-	public static ContextKey<Double> FROST_COUNT_KEY = new ContextKey<>(TFMain.prefix("frost_count"));
-	public static ContextKey<Integer> FROST_ID_KEY = new ContextKey<>(TFMain.prefix("frost_id"));
+	public static final RenderStateDataKey<Double> FROST_COUNT_KEY = RenderStateDataKey.create(() -> "frost_count");
+	public static final RenderStateDataKey<Integer> FROST_ID_KEY = RenderStateDataKey.create(() -> "frost_id");
 
 	public IceLayer(RenderLayerParent<S, M> renderer) {
 		super(renderer);
@@ -31,9 +30,9 @@ public class IceLayer<S extends LivingEntityRenderState, M extends EntityModel<S
 
 	@Override
 	public void submit(PoseStack stack, SubmitNodeCollector submitNodeCollector, int light, S state, float netHeadYaw, float headPitch) {
-		Double count = state.getRenderData(FROST_COUNT_KEY);
+		Double count = state.getData(FROST_COUNT_KEY);
 		if (count == null || count <= 0.0D) return;
-		Integer id = state.getRenderData(FROST_ID_KEY);
+		Integer id = state.getData(FROST_ID_KEY);
 		if (id == null) return;
 
 		this.random.setSeed(id * id * 3121L + id * 45238971L);

--- a/src/main/java/twilightforest/client/renderer/tooltip/TravellersBeltTooltipComponent.java
+++ b/src/main/java/twilightforest/client/renderer/tooltip/TravellersBeltTooltipComponent.java
@@ -5,8 +5,8 @@ import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.ItemContainerContents;
 import twilightforest.item.travellers_gear.TravellersArmorBeltItem;
 
 import java.util.ArrayList;
@@ -18,11 +18,9 @@ public class TravellersBeltTooltipComponent implements ClientTooltipComponent {
 	private final List<ItemStack> contents = new ArrayList<>();
 
 	public TravellersBeltTooltipComponent(TravellersArmorBeltItem.Tooltip tooltip) {
-		ItemContainerContents contents = tooltip.contents();
-		for (int i = 0; i < 9; i++) {
-			ItemStack stack = contents.getSlots() <= i ? ItemStack.EMPTY : contents.getStackInSlot(i);
-			this.contents.add(stack);
-		}
+		NonNullList<ItemStack> slots = NonNullList.withSize(9, ItemStack.EMPTY);
+		tooltip.contents().copyInto(slots);
+		this.contents.addAll(slots);
 	}
 
 	@Override


### PR DESCRIPTION
- SkullChestRenderer: TwilightForestMod -> TFMain
- IceLayer: NeoForge ContextKey/getRenderData -> Fabric RenderStateDataKey with plain string debug names, read via FabricRenderState.getData
- TravellersBeltTooltipComponent: ItemContainerContents no longer has getSlots()/getStackInSlot in 26.1, copy into a NonNullList instead