### PR TITLE
Drop removed getRenderBoundingBox overrides in TF particles

### DIFF
--- a/src/main/java/twilightforest/client/particle/LogCoreParticle.java
+++ b/src/main/java/twilightforest/client/particle/LogCoreParticle.java
@@ -6,7 +6,6 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.phys.AABB;
 
 public class LogCoreParticle extends RisingParticle {
 	LogCoreParticle(ClientLevel pLevel, double pX, double pY, double pZ, double pXSpeed, double pYSpeed, double pZSpeed, TextureAtlasSprite sprite) {
@@ -64,8 +63,4 @@ public class LogCoreParticle extends RisingParticle {
 		}
 	}
 
-	@Override
-	public AABB getRenderBoundingBox(float partialTicks) {
-		return AABB.INFINITE;
-	}
 }

--- a/src/main/java/twilightforest/client/particle/SortingParticle.java
+++ b/src/main/java/twilightforest/client/particle/SortingParticle.java
@@ -6,7 +6,6 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.phys.AABB;
 
 public class SortingParticle extends SingleQuadParticle {
 	private final double xStart;
@@ -90,8 +89,4 @@ public class SortingParticle extends SingleQuadParticle {
 		}
 	}
 
-	@Override
-	public AABB getRenderBoundingBox(float partialTicks) {
-		return AABB.INFINITE;
-	}
 }

--- a/src/main/java/twilightforest/client/particle/TransformationParticle.java
+++ b/src/main/java/twilightforest/client/particle/TransformationParticle.java
@@ -6,7 +6,6 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.phys.AABB;
 
 public class TransformationParticle extends SingleQuadParticle {
 	private final double xStart;
@@ -90,8 +89,4 @@ public class TransformationParticle extends SingleQuadParticle {
 		}
 	}
 
-	@Override
-	public AABB getRenderBoundingBox(float partialTicks) {
-		return AABB.INFINITE;
-	}
 }


### PR DESCRIPTION
Particle.getRenderBoundingBox and AABB.INFINITE no longer exist in 26.1; matches upstream, which commented these out.