### PR TITLE
Replace beanification with manual init in FoliageColorHandler

### DIFF
--- a/src/main/java/twilightforest/asm/hooks/coremod/BlockHooks.java
+++ b/src/main/java/twilightforest/asm/hooks/coremod/BlockHooks.java
@@ -13,7 +13,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.phys.Vec3;
-import tamaized.beanification.Autowired;
 import twilightforest.block.CloudBlock;
 import twilightforest.block.SnowLoggable;
 import twilightforest.block.WroughtIronFenceBlock;
@@ -25,8 +24,7 @@ import twilightforest.init.custom.TravellersModifiersManager;
 @SuppressWarnings({"JavadocReference", "unused"})
 public class BlockHooks {
 
-	@Autowired
-	private static FoliageColorHandler foliageColorHandler;
+	private static final FoliageColorHandler foliageColorHandler = FoliageColorHandler.INSTANCE;
 
 	/**
 	 * {@link twilightforest.asm.transformers.cloud.IsRainingAtTransformer}<p/>
@@ -84,7 +82,7 @@ public class BlockHooks {
 	 * Targets: {@link BlockState#canSustainPlant(BlockGetter, BlockPos, Direction, BlockState)}
 	 */
 	public static TriState modifySoilDecisionForMushroomBlockSurvivability(TriState o, LevelReader level, BlockPos pos) {
-		if (!o.isDefault())
+		if (o != TriState.DEFAULT)
 			return o; // Short-circuit - We should not override non-default soil behaviour otherwise this would allow Mushrooms to survive on ALL blocks
 		for (int x = -1; x <= 1; x++) {
 			for (int z = -1; z <= 1; z++) {

--- a/src/main/java/twilightforest/client/FoliageColorHandler.java
+++ b/src/main/java/twilightforest/client/FoliageColorHandler.java
@@ -1,27 +1,22 @@
 package twilightforest.client;
 
 import com.google.common.collect.MapMaker;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
 import net.minecraft.client.Minecraft;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.biome.Biome;
-import net.neoforged.bus.api.IEventBus;
-import net.neoforged.neoforge.event.entity.EntityLeaveLevelEvent;
-import tamaized.beanification.Autowired;
-import tamaized.beanification.Component;
-import tamaized.beanification.PostConstruct;
 import twilightforest.init.TFBiomes;
 import twilightforest.world.components.BiomeColorAlgorithms;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Component
 public final class FoliageColorHandler {
 
-	@Autowired
-	private BiomeColorAlgorithms biomeColorAlgorithms;
+	public static final FoliageColorHandler INSTANCE = new FoliageColorHandler();
+
+	private final BiomeColorAlgorithms biomeColorAlgorithms = BiomeColorAlgorithms.INSTANCE;
 
 	private final Map<ResourceKey<Biome>, Handler> REGISTRY = new HashMap<>() {{
 		put(TFBiomes.SPOOKY_FOREST, (o, x, z) -> biomeColorAlgorithms.spookyFoliage(x, z));
@@ -33,13 +28,8 @@ public final class FoliageColorHandler {
 
 	private final Map<Biome, Handler> HANDLES = new MapMaker().weakKeys().makeMap(); // Concurrent + Weak + Hash
 
-	@PostConstruct(PostConstruct.Bus.GAME)
-	private void setup(IEventBus bus) {
-		bus.addListener(EntityLeaveLevelEvent.class, event -> {
-			if (event.getLevel().isClientSide()) {
-				HANDLES.clear();
-			}
-		});
+	public void init() {
+		ClientEntityEvents.ENTITY_UNLOAD.register((entity, level) -> HANDLES.clear());
 	}
 
 	public int get(int o, Biome biome, double x, double z) {
@@ -47,15 +37,11 @@ public final class FoliageColorHandler {
 		if (handler == null) {
 			handler = REGISTRY.getOrDefault(
 				Minecraft.getInstance().level == null ? null :
-					Minecraft.getInstance().level.registryAccess().registryOrThrow(Registries.BIOME).getResourceKey(biome).orElse(null),
+					Minecraft.getInstance().level.registryAccess().lookupOrThrow(Registries.BIOME).getResourceKey(biome).orElse(null),
 				Handler.DEFAULT);
 			HANDLES.put(biome, handler);
 		}
 		return handler.apply(o, x, z);
-	}
-
-	public static int getTintColorAtPosition(BlockPos pos) {
-
 	}
 
 	@FunctionalInterface


### PR DESCRIPTION
- Drop Component/Autowired/PostConstruct annotations and the NeoForge event bus; FoliageColorHandler is now a manual singleton and clears its cache via ClientEntityEvents.ENTITY_UNLOAD
- BlockHooks uses FoliageColorHandler.INSTANCE directly
- Adapt to 26.1 APIs: RegistryAccess.registryOrThrow -> lookupOrThrow, TriState.isDefault -> == TriState.DEFAULT
- Remove the empty getTintColorAtPosition stub (no callers)