### PR TITLE
Use upstream's supplier-based BakedMultiPartRenderers

### DIFF
--- a/src/main/java/twilightforest/client/BakedMultiPartRenderers.java
+++ b/src/main/java/twilightforest/client/BakedMultiPartRenderers.java
@@ -1,10 +1,10 @@
 package twilightforest.client;
 
+import com.google.common.base.Suppliers;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.NoopRenderer;
 import net.minecraft.resources.Identifier;
-import net.minecraft.util.LazyLoadedValue;
 import twilightforest.client.model.TFModelLayers;
 import twilightforest.client.model.entity.HydraHeadModel;
 import twilightforest.client.model.entity.HydraNeckModel;
@@ -18,20 +18,21 @@ import twilightforest.entity.boss.SnowQueenIceShield;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @SuppressWarnings("deprecation")
 public class BakedMultiPartRenderers {
-	private static final Map<Identifier, LazyLoadedValue<EntityRenderer<?>>> renderers = new HashMap<>();
+	private static final Map<Identifier, Supplier<EntityRenderer<?,?>>> renderers = new HashMap<>();
 
 	public static void bakeMultiPartRenderers(EntityRendererProvider.Context context) {
-		renderers.put(TFPart.RENDERER, new LazyLoadedValue<>(() -> new NoopRenderer<>(context)));
-		renderers.put(HydraHead.RENDERER, new LazyLoadedValue<>(() -> new HydraHeadRenderer<>(context, new HydraHeadModel<>(context.bakeLayer(TFModelLayers.HYDRA_HEAD)))));
-		renderers.put(HydraNeck.RENDERER, new LazyLoadedValue<>(() -> new HydraNeckRenderer<>(context, new HydraNeckModel(context.bakeLayer(TFModelLayers.HYDRA_NECK)))));
-		renderers.put(SnowQueenIceShield.RENDERER, new LazyLoadedValue<>(() -> new SnowQueenIceShieldRenderer<>(context)));
-		renderers.put(NagaSegment.RENDERER, new LazyLoadedValue<>(() -> new NagaSegmentRenderer<>(context, new NagaModel<>(context.bakeLayer(TFModelLayers.NAGA_BODY)))));
+		renderers.put(TFPart.RENDERER, Suppliers.memoize(() -> new NoopRenderer<>(context)));
+		renderers.put(HydraHead.RENDERER, Suppliers.memoize(() -> new HydraHeadRenderer(context, new HydraHeadModel(context.bakeLayer(TFModelLayers.HYDRA_HEAD)))));
+		renderers.put(HydraNeck.RENDERER, Suppliers.memoize(() -> new HydraNeckRenderer(context, new HydraNeckModel(context.bakeLayer(TFModelLayers.HYDRA_NECK)))));
+		renderers.put(SnowQueenIceShield.RENDERER, Suppliers.memoize(() -> new SnowQueenIceShieldRenderer(context)));
+		renderers.put(NagaSegment.RENDERER, Suppliers.memoize(() -> new NagaSegmentRenderer(context, new NagaModel<>(context.bakeLayer(TFModelLayers.NAGA_BODY)))));
 	}
 
-	public static EntityRenderer<?> lookup(Identifier location) {
+	public static EntityRenderer<?,?> lookup(Identifier location) {
 		return renderers.get(location).get();
 	}
 }


### PR DESCRIPTION
LazyLoadedValue was removed in 26.1 and EntityRenderer now takes two type parameters, so sync with upstream's version using Guava Suppliers.memoize and EntityRenderer<?, ?>.