### PR TITLE
Port JarRenderer to Fabric

### DIFF
--- a/src/main/java/twilightforest/client/renderer/block/JarRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/block/JarRenderer.java
@@ -1,50 +1,49 @@
 package twilightforest.client.renderer.block;
 
+import com.google.common.base.Suppliers;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
-import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.DecoratedPotBlockEntity.WobbleStyle;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.RotationSegment;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.neoforge.client.RenderTypeHelper;
-import net.neoforged.neoforge.client.model.data.ModelData;
-import net.neoforged.neoforge.common.util.Lazy;
-import net.neoforged.neoforge.registries.DeferredBlock;
-import tamaized.beanification.Autowired;
-import tamaized.beanification.Configurable;
+import net.minecraft.world.phys.Vec3;
+import org.jspecify.annotations.Nullable;
 import twilightforest.block.entity.JarBlockEntity;
 import twilightforest.block.entity.MasonJarBlockEntity;
-import twilightforest.enums.extensions.TFItemDisplayContextEnumExtension;
+import twilightforest.client.state.block.JarRenderState;
 import twilightforest.init.TFBlocks;
 
-import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 //TODO I ideally want to move the jar lids to be data driven
-public class JarRenderer<T extends JarBlockEntity> implements BlockEntityRenderer<T> {
-	public static final Map<Item, BakedModel> LIDS = new HashMap<>();
+public class JarRenderer<T extends JarBlockEntity> implements BlockEntityRenderer<T, JarRenderState> {
+//	public static final Map<Item, BakedModel> LIDS = new HashMap<>();
 
 	public record LidResource(Item lid, Identifier identifier, @Nullable String customPath) {
-		public LidResource(DeferredBlock<?> lid) {
-			this(lid.asItem(), lid.getId(), null);
+		public LidResource(Block lid) {
+			this(lid.asItem(), BuiltInRegistries.BLOCK.getKey(lid), null);
 		}
 
 		public LidResource(Item item, String path) {
@@ -56,7 +55,7 @@ public class JarRenderer<T extends JarBlockEntity> implements BlockEntityRendere
 		}
 	}
 
-	public static final Lazy<List<LidResource>> LID_LOCATION_LIST = Lazy.of(() -> List.of(
+	public static final Supplier<List<LidResource>> LID_LOCATION_LIST = Suppliers.memoize(() -> List.of(
 		new LidResource(TFBlocks.MANGROVE_LOG),
 		new LidResource(TFBlocks.CANOPY_LOG),
 		new LidResource(TFBlocks.DARK_LOG),
@@ -99,11 +98,23 @@ public class JarRenderer<T extends JarBlockEntity> implements BlockEntityRendere
 		new LidResource(Items.STRIPPED_BAMBOO_BLOCK, "stripped_bamboo_block")
 	));
 
-	protected final BlockRenderDispatcher blockRenderer;
+//	protected final BlockRenderDispatcher blockRenderer;
 	protected static final float WOBBLE_AMPLITUDE = 0.125F;
 
 	public JarRenderer(BlockEntityRendererProvider.Context context) {
-		this.blockRenderer = context.getBlockRenderDispatcher();
+//		this.blockRenderer = context.getBlockRenderDispatcher();
+	}
+
+	@Override
+	public JarRenderState createRenderState() {
+		return new JarRenderState();
+	}
+
+	@Override
+	public void extractRenderState(T blockEntity, JarRenderState state, float partialTicks, Vec3 cameraPosition, ModelFeatureRenderer.CrumblingOverlay breakProgress) {
+		BlockEntityRenderer.super.extractRenderState(blockEntity, state, partialTicks, cameraPosition, breakProgress);
+		state.lastWobbleStyle = blockEntity.lastWobbleStyle;
+		state.gameTime = blockEntity.getLevel() != null ? ((float) (blockEntity.getLevel().getGameTime() - blockEntity.wobbleStartedAtTick) + blockEntity.getLevel().getGameTime()) : 0L;
 	}
 
 	@Override
@@ -112,15 +123,15 @@ public class JarRenderer<T extends JarBlockEntity> implements BlockEntityRendere
 	}
 
 	@Override
-	public void render(T blockEntity, float partialTick, PoseStack poseStack, MultiBufferSource buffer, int packedLight, int packedOverlay) {
+	public void submit(JarRenderState blockEntity, PoseStack poseStack, SubmitNodeCollector buffer, CameraRenderState camera) {
 		poseStack.pushPose();
 		poseStack.translate(0.5, 0.0, 0.5);
 		poseStack.mulPose(Axis.YP.rotationDegrees(180.0F));
 		poseStack.translate(-0.5, 0.0, -0.5);
 		WobbleStyle wobbleStyle = blockEntity.lastWobbleStyle;
 
-		if (wobbleStyle != null && blockEntity.getLevel() != null) {
-			float f = ((float) (blockEntity.getLevel().getGameTime() - blockEntity.wobbleStartedAtTick) + partialTick) / (float) wobbleStyle.duration;
+		if (wobbleStyle != null) {
+			float f = blockEntity.gameTime / (float) wobbleStyle.duration;
 			if (f >= 0.0F && f <= 1.0F) {
 				if (wobbleStyle == WobbleStyle.POSITIVE) {
 					float f1 = 0.015625F;
@@ -137,60 +148,56 @@ public class JarRenderer<T extends JarBlockEntity> implements BlockEntityRendere
 			}
 		}
 
-		BlockState state = blockEntity.getBlockState();
-		if (LIDS.containsKey(blockEntity.lid)) renderModel(LIDS.get(blockEntity.lid), state, this.blockRenderer, poseStack, buffer, packedLight, packedOverlay);
-		renderJarModel(state, this.blockRenderer, poseStack, buffer, packedLight, packedOverlay);
-		this.renderContents(blockEntity, partialTick, poseStack, buffer, packedLight, packedOverlay);
+//		BlockState state = blockEntity.getBlockState();
+//		if (LIDS.containsKey(blockEntity.lid)) renderModel(LIDS.get(blockEntity.lid), state, this.blockRenderer, poseStack, buffer, packedLight, packedOverlay);
+//		renderJarModel(state, this.blockRenderer, poseStack, buffer, packedLight, packedOverlay);
+//		this.renderContents(blockEntity, partialTick, poseStack, buffer, packedLight, packedOverlay);
 
 		poseStack.popPose();
 	}
 
-	public static void renderJarModel(BlockState blockState, BlockRenderDispatcher blockRenderer, PoseStack stack, MultiBufferSource buffer, int packedLight, int packedOverlay) {
-		BakedModel bakedModel = blockRenderer.getBlockModel(blockState);
-		renderModel(bakedModel, blockState, blockRenderer, stack, buffer, packedLight, packedOverlay);
-	}
+//	public static void renderJarModel(BlockState blockState, BlockRenderDispatcher blockRenderer, PoseStack stack, MultiBufferSource buffer, int packedLight, int packedOverlay) {
+//		BakedModel bakedModel = blockRenderer.getBlockModel(blockState);
+//		renderModel(bakedModel, blockState, blockRenderer, stack, buffer, packedLight, packedOverlay);
+//	}
 
-	public static void renderModel(BakedModel bakedModel, BlockState blockState, BlockRenderDispatcher blockRenderer, PoseStack stack, MultiBufferSource buffer, int packedLight, int packedOverlay) {
-		int color = blockRenderer.blockColors.getColor(blockState, null, null, 0);
-		float r = (float) (color >> 16 & 0xFF) / 255.0F;
-		float g = (float) (color >> 8 & 0xFF) / 255.0F;
-		float b = (float) (color & 0xFF) / 255.0F;
-		for (RenderType rt : bakedModel.getRenderTypes(blockState, RandomSource.create(42), ModelData.EMPTY))
-			blockRenderer.getModelRenderer()
-				.renderModel(
-					stack.last(),
-					buffer.getBuffer(RenderTypeHelper.getEntityRenderType(rt, false)),
-					blockState,
-					bakedModel,
-					r,
-					g,
-					b,
-					packedLight,
-					packedOverlay,
-					ModelData.EMPTY,
-					rt
-				);
-	}
+//	public static void renderModel(BakedModel bakedModel, BlockState blockState, BlockRenderDispatcher blockRenderer, PoseStack stack, MultiBufferSource buffer, int packedLight, int packedOverlay) {
+//		int color = blockRenderer.blockColors.getColor(blockState, null, null, 0);
+//		float r = (float) (color >> 16 & 0xFF) / 255.0F;
+//		float g = (float) (color >> 8 & 0xFF) / 255.0F;
+//		float b = (float) (color & 0xFF) / 255.0F;
+//		for (RenderType rt : bakedModel.getRenderTypes(blockState, RandomSource.create(42), ModelData.EMPTY))
+//			blockRenderer.getModelRenderer()
+//				.renderModel(
+//					stack.last(),
+//					buffer.getBuffer(RenderTypeHelper.getEntityRenderType(rt, false)),
+//					blockState,
+//					bakedModel,
+//					r,
+//					g,
+//					b,
+//					packedLight,
+//					packedOverlay,
+//					ModelData.EMPTY,
+//					rt
+//				);
+//	}
 
 	public void renderContents(T blockEntity, float partialTick, PoseStack poseStack, MultiBufferSource buffer, int packedLight, int packedOverlay) {
 
 	}
 
-	@Configurable
 	public static class MasonJarRenderer extends JarRenderer<MasonJarBlockEntity> {
 
-		@Autowired(dist = Dist.CLIENT)
-		private TFItemDisplayContextEnumExtension itemDisplayContextEnumExtension;
-
-		protected final ItemRenderer itemRenderer;
-		protected final EntityRenderDispatcher entityRender;
-		protected final Font font;
+//		protected final ItemRenderer itemRenderer;
+//		protected final EntityRenderDispatcher entityRender;
+//		protected final Font font;
 
 		public MasonJarRenderer(BlockEntityRendererProvider.Context context) {
 			super(context);
-			this.entityRender = context.getEntityRenderer();
-			this.itemRenderer = context.getItemRenderer();
-			this.font = context.getFont();
+//			this.entityRender = context.getEntityRenderer();
+//			this.itemRenderer = context.getItemRenderer();
+//			this.font = context.getFont();
 		}
 
 		@Override
@@ -204,7 +211,7 @@ public class JarRenderer<T extends JarBlockEntity> implements BlockEntityRendere
 				poseStack.mulPose(Axis.YN.rotationDegrees(RotationSegment.convertToDegrees(blockEntity.getItemRotation())));
 
 				poseStack.scale(0.5F, 0.5F, 0.5F);
-				this.itemRenderer.renderStatic(stack, itemDisplayContextEnumExtension.JARRED, packedLight, OverlayTexture.NO_OVERLAY, poseStack, buffer, null, 0);
+//				this.itemRenderer.renderStatic(stack, itemDisplayContextEnumExtension.JARRED, packedLight, OverlayTexture.NO_OVERLAY, poseStack, buffer, null, 0);
 
 
 				poseStack.popPose();

--- a/src/main/java/twilightforest/client/state/block/JarRenderState.java
+++ b/src/main/java/twilightforest/client/state/block/JarRenderState.java
@@ -1,0 +1,10 @@
+package twilightforest.client.state.block;
+
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.world.level.block.entity.DecoratedPotBlockEntity;
+
+public class JarRenderState extends BlockEntityRenderState {
+
+	public DecoratedPotBlockEntity.WobbleStyle lastWobbleStyle;
+	public float gameTime;
+}


### PR DESCRIPTION
Sync with upstream's 26.1 rework (two-parameter BlockEntityRenderer, JarRenderState, supplier-based lid list) and drop the NeoForge/beanification bits:

- Lazy<DeferredBlock...> -> Guava Suppliers.memoize, LidResource takes a Block (id from BuiltInRegistries.BLOCK)
- remove @Configurable/@Autowired (MasonJarRenderer) and the enum extension injection
- javax.annotation.Nullable -> org.jspecify.annotations.Nullable
- add the missing JarRenderState class