### PR TITLE
Port QuestingRamIndicatorOverlay to Fabric

### DIFF
--- a/src/main/java/twilightforest/client/overlay/QuestingRamIndicatorOverlay.java
+++ b/src/main/java/twilightforest/client/overlay/QuestingRamIndicatorOverlay.java
@@ -1,16 +1,13 @@
 package twilightforest.client.overlay;
 
-import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameType;
-import net.neoforged.api.distmarker.Dist;
-import tamaized.beanification.Autowired;
 import twilightforest.TFMain;
 import twilightforest.config.TFConfig;
 import twilightforest.entity.passive.QuestRam;
@@ -21,27 +18,24 @@ public class QuestingRamIndicatorOverlay {
 	private static final Identifier QUESTING_RAM_CHECK_SPRITE = TFMain.prefix("questing_ram_check");
 	private static final Identifier QUESTING_RAM_X_SPRITE = TFMain.prefix("questing_ram_x");
 
-	@Autowired(dist = Dist.CLIENT)
-	private static QuestingRamCurrentContext questingRamCurrentContext;
-
-	public static void render(Minecraft minecraft, GuiGraphics graphics, Gui gui, Player player) {
+	public static void render(Minecraft minecraft, GuiGraphicsExtractor graphics, Gui gui, Player player) {
 		if (player != null && !minecraft.options.hideGui && TFConfig.showQuestRamCrosshairIndicator) {
 			if (minecraft.options.getCameraType().isFirstPerson() && (minecraft.gameMode.getPlayerMode() != GameType.SPECTATOR || gui.canRenderCrosshairForSpectator(minecraft.hitResult)) && minecraft.crosshairPickEntity instanceof QuestRam ram) {
-				ItemStack stack = player.getInventory().getItem(player.getInventory().selected);
+				ItemStack stack = player.getInventory().getItem(player.getInventory().getSelectedSlot());
 				if (!stack.isEmpty()) {
-					for (var questEntry : questingRamCurrentContext.getContext().questItems().entrySet()) {
+					for (var questEntry : QuestingRamCurrentContext.INSTANCE.getContext().questItems().entrySet()) {
 						if (questEntry.getValue().test(stack)) {
-							RenderSystem.enableBlend();
-							RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.ONE_MINUS_DST_COLOR, GlStateManager.DestFactor.ONE_MINUS_SRC_COLOR, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+//							RenderSystem.enableBlend();
+//							RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.ONE_MINUS_DST_COLOR, GlStateManager.DestFactor.ONE_MINUS_SRC_COLOR, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
 							int j = ((graphics.guiHeight() - 1) / 2) - 11;
 							int k = ((graphics.guiHeight() - 1) / 2) - 3;
 							if (!ram.isColorPresent(questEntry.getKey())) {
-								graphics.blitSprite(QUESTING_RAM_X_SPRITE, k, j, 7, 7);
+//								graphics.blitSprite(QUESTING_RAM_X_SPRITE, k, j, 7, 7);
 							} else {
-								graphics.blitSprite(QUESTING_RAM_CHECK_SPRITE, k, j, 7, 7);
+//								graphics.blitSprite(QUESTING_RAM_CHECK_SPRITE, k, j, 7, 7);
 							}
-							RenderSystem.defaultBlendFunc();
-							RenderSystem.disableBlend();
+//							RenderSystem.defaultBlendFunc();
+//							RenderSystem.disableBlend();
 							break;
 						}
 					}


### PR DESCRIPTION
Sync with upstream's 26.1 adaptation (GuiGraphicsExtractor, getSelectedSlot, commented-out blend/blitSprite calls) and drop the beanification injection:

- use QuestingRamCurrentContext.INSTANCE instead of @Autowired
- TwilightForestMod -> TFMain