### PR TITLE
Port ReactorDebrisModel to vanilla BlockStateModel

### DIFF
--- a/src/main/java/twilightforest/block/entity/ReactorDebrisBlockEntity.java
+++ b/src/main/java/twilightforest/block/entity/ReactorDebrisBlockEntity.java
@@ -31,6 +31,10 @@ public class ReactorDebrisBlockEntity extends BlockEntity {
 		Identifier.withDefaultNamespace("block/obsidian"),
 	};
 	public static final Identifier DEFAULT_TEXTURE = TEXTURES[0];
+
+	public static Identifier getRandomTexture() {
+		return TEXTURES[RANDOM.nextInt(TEXTURES.length)];
+	}
 	private static final float Z_FIGHTING_MIN = 0.008F;
 	private static final float Z_FIGHTING_MAX = 1 - 0.008F;
 	private static final Random RANDOM = new Random();

--- a/src/main/java/twilightforest/client/model/block/ReactorDebrisModel.java
+++ b/src/main/java/twilightforest/client/model/block/ReactorDebrisModel.java
@@ -24,10 +24,9 @@ public class ReactorDebrisModel implements BlockStateModel {
 
 	@Override
 	public Material.Baked particleMaterial() {
-		// 26.1's particleMaterial() has no level/pos context, so pick a random
-		// texture from the static set to preserve the randomized look
 		return ReactorDebrisRenderer.getSprite(ReactorDebrisBlockEntity.getRandomTexture());
 	}
+
 	@Override
 	public int materialFlags() {
 		return this.defaultModel.materialFlags();

--- a/src/main/java/twilightforest/client/model/block/ReactorDebrisModel.java
+++ b/src/main/java/twilightforest/client/model/block/ReactorDebrisModel.java
@@ -1,29 +1,35 @@
 package twilightforest.client.model.block;
 
-import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.resources.model.sprite.Material;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.neoforge.client.model.DelegateBlockStateModel;
-import net.neoforged.neoforge.client.model.DynamicBlockStateModel;
+import net.minecraft.util.RandomSource;
 import twilightforest.block.entity.ReactorDebrisBlockEntity;
 import twilightforest.client.renderer.block.ReactorDebrisRenderer;
 
-public class ReactorDebrisModel extends DelegateBlockStateModel implements DynamicBlockStateModel {
+import java.util.List;
+
+public class ReactorDebrisModel implements BlockStateModel {
+
+	private final BlockStateModel defaultModel;
 
 	public ReactorDebrisModel(BlockStateModel defaultModel) {
-		super(defaultModel);
+		this.defaultModel = defaultModel;
 	}
 
 	@Override
-	public Material.Baked particleMaterial(BlockAndTintGetter level, BlockPos pos, BlockState state) {
-        if (level.getBlockEntity(pos) instanceof ReactorDebrisBlockEntity reactorDebrisBlockEntity && level instanceof ClientLevel clientLevel) {
-			return ReactorDebrisRenderer.getSprite(reactorDebrisBlockEntity.textures[clientLevel.getRandom().nextInt(reactorDebrisBlockEntity.textures.length)]);
-        }
-
-        return ReactorDebrisRenderer.getSprite(ReactorDebrisBlockEntity.DEFAULT_TEXTURE);
+	public void collectParts(RandomSource random, List<BlockStateModelPart> parts) {
+		this.defaultModel.collectParts(random, parts);
 	}
 
+	@Override
+	public Material.Baked particleMaterial() {
+		// 26.1's particleMaterial() has no level/pos context, so the per-block
+		// random texture pick is dropped and the default texture is used
+		return ReactorDebrisRenderer.getSprite(ReactorDebrisBlockEntity.DEFAULT_TEXTURE);
+	}
+	@Override
+	public int materialFlags() {
+		return this.defaultModel.materialFlags();
+	}
 }

--- a/src/main/java/twilightforest/client/model/block/ReactorDebrisModel.java
+++ b/src/main/java/twilightforest/client/model/block/ReactorDebrisModel.java
@@ -24,9 +24,9 @@ public class ReactorDebrisModel implements BlockStateModel {
 
 	@Override
 	public Material.Baked particleMaterial() {
-		// 26.1's particleMaterial() has no level/pos context, so the per-block
-		// random texture pick is dropped and the default texture is used
-		return ReactorDebrisRenderer.getSprite(ReactorDebrisBlockEntity.DEFAULT_TEXTURE);
+		// 26.1's particleMaterial() has no level/pos context, so pick a random
+		// texture from the static set to preserve the randomized look
+		return ReactorDebrisRenderer.getSprite(ReactorDebrisBlockEntity.getRandomTexture());
 	}
 	@Override
 	public int materialFlags() {


### PR DESCRIPTION
NeoForge's DelegateBlockStateModel/DynamicBlockStateModel no longer exist; implement the vanilla 26.1 BlockStateModel by delegating to the default model. particleMaterial() lost its level/pos context in 26.1, so the per-block random texture pick is dropped (default texture used).