### PR TITLE
Adapt TFItemStackUtils to 26.1 APIs

### DIFF
--- a/src/main/java/twilightforest/util/TFItemStackUtils.java
+++ b/src/main/java/twilightforest/util/TFItemStackUtils.java
@@ -21,13 +21,12 @@ import net.minecraft.world.item.component.BlockItemStateProperties;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.ItemLike;
-import org.codehaus.plexus.util.StringUtils;
 import twilightforest.TFMain;
 import twilightforest.block.KeepsakeCasketBlock;
 import twilightforest.events.CharmEvents;
 import twilightforest.init.TFDataComponents;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,7 +54,7 @@ public class TFItemStackUtils {
 			if (blockItemStateProperties != null && blockItemStateProperties.properties().containsKey(KeepsakeCasketBlock.BREAKAGE.getName())) {
 				String propertyValueString = blockItemStateProperties.properties().get(KeepsakeCasketBlock.BREAKAGE.getName());
 
-				persistentTag.putInt(CharmEvents.CASKET_DAMAGE_TAG, StringUtils.isNumeric(propertyValueString) ? Integer.parseInt(propertyValueString) : 0);
+				persistentTag.putInt(CharmEvents.CASKET_DAMAGE_TAG, propertyValueString.matches("[0-9]+") ? Integer.parseInt(propertyValueString) : 0);
 			} else if (stack.has(TFDataComponents.CASKET_DAMAGE)) {
 				persistentTag.putInt(CharmEvents.CASKET_DAMAGE_TAG, stack.getOrDefault(TFDataComponents.CASKET_DAMAGE, 0));
 			}
@@ -103,7 +102,7 @@ public class TFItemStackUtils {
 
 	public static boolean hasInfoTag(ItemStack stack, String key) {
 		CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
-		return customData != null && customData.contains(key);
+		return customData != null && customData.copyTag().contains(key);
 	}
 
 	public static void addInfoTag(ItemStack stack, String key) {
@@ -162,23 +161,17 @@ public class TFItemStackUtils {
 
 
 	public static void hurtButDontBreak(ItemStack stack, int amount, ServerLevel level, @Nullable LivingEntity entity) {
-		if (stack.isDamageableItem()) {
-			amount = stack.getItem().damageItem(stack, amount, entity, _ -> {});
-			if (entity == null || !entity.hasInfiniteMaterials()) {
-				if (amount > 0) {
-					amount = EnchantmentHelper.processDurabilityChange(level, stack, amount);
-					if (amount <= 0) {
-						return;
-					}
-				}
-
-				if (entity instanceof ServerPlayer sp && amount != 0) {
-					CriteriaTriggers.ITEM_DURABILITY_CHANGED.trigger(sp, stack, stack.getDamageValue() + amount);
-				}
-
-				int i = stack.getDamageValue() + amount;
-				stack.setDamageValue(i);
+		if (stack.isDamageableItem() && (entity == null || !entity.hasInfiniteMaterials())) {
+			amount = EnchantmentHelper.processDurabilityChange(level, stack, amount);
+			if (amount <= 0) {
+				return;
 			}
+
+			if (entity instanceof ServerPlayer sp) {
+				CriteriaTriggers.ITEM_DURABILITY_CHANGED.trigger(sp, stack, stack.getDamageValue() + amount);
+			}
+
+			stack.setDamageValue(stack.getDamageValue() + amount);
 		}
 	}
 

--- a/src/main/java/twilightforest/util/TFItemStackUtils.java
+++ b/src/main/java/twilightforest/util/TFItemStackUtils.java
@@ -54,7 +54,7 @@ public class TFItemStackUtils {
 			if (blockItemStateProperties != null && blockItemStateProperties.properties().containsKey(KeepsakeCasketBlock.BREAKAGE.getName())) {
 				String propertyValueString = blockItemStateProperties.properties().get(KeepsakeCasketBlock.BREAKAGE.getName());
 
-				persistentTag.putInt(CharmEvents.CASKET_DAMAGE_TAG, propertyValueString.matches("[0-9]+") ? Integer.parseInt(propertyValueString) : 0);
+				persistentTag.putInt(CharmEvents.CASKET_DAMAGE_TAG, propertyValueString != null && propertyValueString.chars().allMatch(Character::isDigit) ? Integer.parseInt(propertyValueString) : 0);
 			} else if (stack.has(TFDataComponents.CASKET_DAMAGE)) {
 				persistentTag.putInt(CharmEvents.CASKET_DAMAGE_TAG, stack.getOrDefault(TFDataComponents.CASKET_DAMAGE, 0));
 			}


### PR DESCRIPTION
- StringUtils.isNumeric -> String.matches (plexus.util is not a dependency)
- CustomData.contains -> copyTag().contains
- Item.damageItem no longer exists; apply EnchantmentHelper.processDurabilityChange directly and set damage manually
- javax.annotation.Nullable -> org.jspecify.annotations.Nullable