### PR TITLE
Adapt EntityUtil to 26.1/Fabric APIs

### DIFF
--- a/src/main/java/twilightforest/asm/mixin/LivingEntityGetDeathSoundAccessor.java
+++ b/src/main/java/twilightforest/asm/mixin/LivingEntityGetDeathSoundAccessor.java
@@ -1,4 +1,4 @@
-package twilightforest.asm.mixin.coremod;
+package twilightforest.asm.mixin;
 
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.LivingEntity;

--- a/src/main/java/twilightforest/asm/mixin/coremod/LivingEntityGetDeathSoundAccessor.java
+++ b/src/main/java/twilightforest/asm/mixin/coremod/LivingEntityGetDeathSoundAccessor.java
@@ -1,0 +1,12 @@
+package twilightforest.asm.mixin.coremod;
+
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(LivingEntity.class)
+public interface LivingEntityGetDeathSoundAccessor {
+	@Invoker("getDeathSound")
+	SoundEvent twilightforest$invokeGetDeathSound();
+}

--- a/src/main/java/twilightforest/util/entities/EntityUtil.java
+++ b/src/main/java/twilightforest/util/entities/EntityUtil.java
@@ -256,86 +256,82 @@ public class EntityUtil {
 		if (!(oldEntity.level() instanceof ServerLevel level)) return false;
 		var newEntity = newType.create(level, EntitySpawnReason.CONVERSION);
 		if (newEntity == null) return false;
-		boolean firedMobConversion = false;
-		// NeoForge's canLivingConvert event has no Fabric equivalent, so conversion always proceeds
-		{
-			var passengerSave = oldEntity.getPassengers();
-			if (oldEntity instanceof Mob mob && newEntity instanceof Mob newMob) {
-				newEntity = mob.convertTo((EntityType<? extends Mob>) newMob.getType(), ConversionParams.single(newMob, true, true), (ConversionParams.AfterConversion) _ -> {});
-				firedMobConversion = true;
-			} else {
-				newEntity.copyPosition(oldEntity);
-
-				if (newEntity instanceof Mob mob) {
-					if (oldEntity instanceof Mob oldMob) {
-						for (EquipmentSlot equipmentslot : EquipmentSlot.values()) {
-							ItemStack itemstack = oldEntity.getItemBySlot(equipmentslot).copyAndClear();
-							if (!itemstack.isEmpty()) {
-								mob.setItemSlot(equipmentslot, itemstack.copyAndClear());
-								mob.setDropChance(equipmentslot, oldMob.getDropChances().byEquipment(equipmentslot));
-							}
-						}
-					}
-					mob.finalizeSpawn(level, level.getCurrentDifficultyAt(oldEntity.blockPosition()), EntitySpawnReason.CONVERSION, null);
-				}
-
-				oldEntity.level().addFreshEntity(newEntity);
-				oldEntity.discard();
-			}
-			try {
-				UUID uuid = newEntity.getUUID();
-				ProblemReporter reporter = ProblemReporter.DISCARDING;
-				RegistryAccess provider = level.registryAccess();
-				TagValueOutput outputFactory = TagValueOutput.createWithContext(reporter, provider);
-
-				oldEntity.saveWithoutId(outputFactory);
-
-				CompoundTag copiedData = outputFactory.buildResult();
-				ValueInput inputFactory = TagValueInput.create(reporter, provider, copiedData);
-
-				newEntity.load(inputFactory);
-				newEntity.setUUID(uuid);
-
-				if (newEntity instanceof LivingEntity living) {
-					living.setHealth(living.getMaxHealth());
-				}
-			} catch (Exception e) {
-				TFMain.LOGGER.warn("Couldn't transform entity NBT data", e);
-			}
-
-			ItemStack saddleStack = oldEntity.getItemBySlot(EquipmentSlot.SADDLE);
-			if (!saddleStack.isEmpty() && saddleStack.is(Items.SADDLE)) {
-				if (!(newEntity instanceof LivingEntity newLiving) || !newLiving.canUseSlot(EquipmentSlot.SADDLE)) {
-					newEntity.spawnAtLocation(level, Items.SADDLE);
-				} else {
-					newLiving.setItemSlot(EquipmentSlot.SADDLE, saddleStack.copy());
-				}
-			}
+		var passengerSave = oldEntity.getPassengers();
+		if (oldEntity instanceof Mob mob && newEntity instanceof Mob newMob) {
+			newEntity = mob.convertTo((EntityType<? extends Mob>) newMob.getType(), ConversionParams.single(newMob, true, true), (ConversionParams.AfterConversion) _ -> {});
+		} else {
+			newEntity.copyPosition(oldEntity);
 
 			if (newEntity instanceof Mob mob) {
-				mob.spawnAnim();
-				mob.spawnAnim();
-
-				for (EquipmentSlot equipmentslot : EquipmentSlot.values()) {
-					ItemStack itemstack = mob.getItemBySlot(equipmentslot).copyAndClear();
-					mob.spawnAtLocation(level, itemstack);
+				if (oldEntity instanceof Mob oldMob) {
+					for (EquipmentSlot equipmentslot : EquipmentSlot.values()) {
+						ItemStack itemstack = oldEntity.getItemBySlot(equipmentslot).copyAndClear();
+						if (!itemstack.isEmpty()) {
+							mob.setItemSlot(equipmentslot, itemstack.copyAndClear());
+							mob.setDropChance(equipmentslot, oldMob.getDropChances().byEquipment(equipmentslot));
+						}
+					}
 				}
+
+				mob.finalizeSpawn(level, level.getCurrentDifficultyAt(oldEntity.blockPosition()), EntitySpawnReason.CONVERSION, null);
 			}
 
-			if (!passengerSave.isEmpty()) {
-				for (var entity : passengerSave) {
-					entity.startRiding(newEntity, true, false);
-				}
-			}
-
-			if (newEntity instanceof Mob mob && oldEntity instanceof Mob oldMob && !firedMobConversion) {
-				ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(oldMob, mob, ConversionParams.single(mob, true, true));
-			}
-
-			level.playSound(null, newEntity.blockPosition(), TFSounds.POWDER_USE.value(), newEntity.getSoundSource());
-			return true;
+			oldEntity.level().addFreshEntity(newEntity);
+			oldEntity.discard();
 		}
-		return false;
+		try {
+			UUID uuid = newEntity.getUUID();
+			ProblemReporter reporter = ProblemReporter.DISCARDING;
+			RegistryAccess provider = level.registryAccess();
+			TagValueOutput outputFactory = TagValueOutput.createWithContext(reporter, provider);
+
+			oldEntity.saveWithoutId(outputFactory);
+
+			CompoundTag copiedData = outputFactory.buildResult();
+			ValueInput inputFactory = TagValueInput.create(reporter, provider, copiedData);
+
+			newEntity.load(inputFactory);
+			newEntity.setUUID(uuid);
+
+			if (newEntity instanceof LivingEntity living) {
+				living.setHealth(living.getMaxHealth());
+			}
+		} catch (Exception e) {
+			TFMain.LOGGER.warn("Couldn't transform entity NBT data", e);
+		}
+
+		ItemStack saddleStack = oldEntity.getItemBySlot(EquipmentSlot.SADDLE);
+		if (!saddleStack.isEmpty() && saddleStack.is(Items.SADDLE)) {
+			if (!(newEntity instanceof LivingEntity newLiving) || !newLiving.canUseSlot(EquipmentSlot.SADDLE)) {
+				newEntity.spawnAtLocation(level, Items.SADDLE);
+			} else {
+				newLiving.setItemSlot(EquipmentSlot.SADDLE, saddleStack.copy());
+			}
+		}
+
+		if (newEntity instanceof Mob mob) {
+			mob.spawnAnim();
+			mob.spawnAnim();
+
+			for (EquipmentSlot equipmentslot : EquipmentSlot.values()) {
+				ItemStack itemstack = mob.getItemBySlot(equipmentslot).copyAndClear();
+				mob.spawnAtLocation(level, itemstack);
+			}
+		}
+
+		if (!passengerSave.isEmpty()) {
+			for (var entity : passengerSave) {
+				entity.startRiding(newEntity, true, false);
+			}
+		}
+
+		if (newEntity instanceof LivingEntity living) {
+			if (oldEntity instanceof Mob oldMob && living instanceof Mob newMob) {
+				ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(oldMob, newMob, ConversionParams.single(newMob, true, true));
+			}
+		}
+		level.playSound(null, newEntity.blockPosition(), TFSounds.POWDER_USE.value(), newEntity.getSoundSource());
+		return true;
 	}
 
 	@Nullable

--- a/src/main/java/twilightforest/util/entities/EntityUtil.java
+++ b/src/main/java/twilightforest/util/entities/EntityUtil.java
@@ -64,8 +64,7 @@ public class EntityUtil {
 		float hardness = state.getDestroySpeed(world, pos);
 		return hardness >= 0f && hardness < 50f && !state.isAir()
 			&& !(world.getBlockEntity(pos) instanceof Container)
-			&& state.getBlock().carminite$canEntityDestroy(state, world, pos, entity)
-			&& (/* rude type limit */!(entity instanceof LivingEntity));
+			&& state.getBlock().carminite$canEntityDestroy(state, world, pos, entity);
 	}
 
 	/**

--- a/src/main/java/twilightforest/util/entities/EntityUtil.java
+++ b/src/main/java/twilightforest/util/entities/EntityUtil.java
@@ -88,7 +88,7 @@ public class EntityUtil {
 
 	@Nullable
 	public static SoundEvent getDeathSound(LivingEntity living) {
-		return living.getDeathSound();
+		return ((twilightforest.asm.mixin.coremod.LivingEntityGetDeathSoundAccessor) living).twilightforest$invokeGetDeathSound();
 	}
 
 	public static void killLavaAround(Entity entity) {

--- a/src/main/java/twilightforest/util/entities/EntityUtil.java
+++ b/src/main/java/twilightforest/util/entities/EntityUtil.java
@@ -40,16 +40,11 @@ import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.fml.util.ObfuscationReflectionHelper;
-import net.neoforged.neoforge.event.EventHooks;
 import org.jetbrains.annotations.Nullable;
 import twilightforest.TFMain;
 import twilightforest.entity.EnforcedHomePoint;
 import twilightforest.init.TFSounds;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -69,9 +64,7 @@ public class EntityUtil {
 		float hardness = state.getDestroySpeed(world, pos);
 		return hardness >= 0f && hardness < 50f && !state.isAir()
 			&& !(world.getBlockEntity(pos) instanceof Container)
-			&& state.getBlock().canEntityDestroy(state, world, pos, entity)
-			&& (/* rude type limit */!(entity instanceof LivingEntity)
-			|| EventHooks.onEntityDestroyBlock((LivingEntity) entity, pos, state));
+			&& (/* rude type limit */!(entity instanceof LivingEntity));
 	}
 
 	/**
@@ -93,37 +86,9 @@ public class EntityUtil {
 		return rayTrace(player, modifier == null ? range : modifier.applyAsDouble(range));
 	}
 
-	private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-	private static final Method LivingEntity_getDeathSound = ObfuscationReflectionHelper.findMethod(LivingEntity.class, "getDeathSound");
-	private static final MethodHandle handle_LivingEntity_getDeathSound;
-	private static final Method HangingEntity_setDirection = ObfuscationReflectionHelper.findMethod(HangingEntity.class, "setDirection", Direction.class);
-	private static final MethodHandle handle_HangingEntity_setDirection;
-
-	static {
-		MethodHandle tmp_handle_LivingEntity_getDeathSound = null;
-		MethodHandle tmp_handle_HangingEntity_setDirection = null;
-
-		try {
-			tmp_handle_LivingEntity_getDeathSound = LOOKUP.unreflect(LivingEntity_getDeathSound);
-			tmp_handle_HangingEntity_setDirection = LOOKUP.unreflect(HangingEntity_setDirection);
-		} catch (IllegalAccessException e) {
-			e.printStackTrace();
-		}
-		handle_LivingEntity_getDeathSound = tmp_handle_LivingEntity_getDeathSound;
-		handle_HangingEntity_setDirection = tmp_handle_HangingEntity_setDirection;
-	}
-
 	@Nullable
 	public static SoundEvent getDeathSound(LivingEntity living) {
-		SoundEvent sound = null;
-		if (handle_LivingEntity_getDeathSound != null) {
-			try {
-				sound = (SoundEvent) handle_LivingEntity_getDeathSound.invokeExact(living);
-			} catch (Throwable e) {
-				// FAIL SILENTLY
-			}
-		}
-		return sound;
+		return living.getDeathSound();
 	}
 
 	public static void killLavaAround(Entity entity) {
@@ -188,13 +153,7 @@ public class EntityUtil {
 		Painting painting = createEntityIgnoreException(EntityType.PAINTING, world);
 
 		painting.setPos(pos.getX(), pos.getY(), pos.getZ());
-		try {
-			handle_HangingEntity_setDirection.invoke(painting, direction);
-		} catch (Throwable throwable) {
-			throwable.printStackTrace();
-
-			return false;
-		}
+		painting.setDirection(direction);
 		painting.setComponent(DataComponents.PAINTING_VARIANT, chosenPainting);
 
 		if (checkValidPaintingPosition(world, painting)) {
@@ -296,7 +255,8 @@ public class EntityUtil {
 		if (!(oldEntity.level() instanceof ServerLevel level)) return false;
 		var newEntity = newType.create(level, EntitySpawnReason.CONVERSION);
 		if (newEntity == null) return false;
-		if (!(newEntity instanceof LivingEntity living) || EventHooks.canLivingConvert(oldEntity, (EntityType<? extends LivingEntity>) living.getType(), timer -> {})) {
+		// NeoForge's canLivingConvert event has no Fabric equivalent, so conversion always proceeds
+		{
 			var passengerSave = oldEntity.getPassengers();
 			if (oldEntity instanceof Mob mob && newEntity instanceof Mob newMob) {
 				newEntity = mob.convertTo((EntityType<? extends Mob>) newMob.getType(), ConversionParams.single(newMob, true, true), (ConversionParams.AfterConversion) _ -> {});
@@ -313,8 +273,6 @@ public class EntityUtil {
 							}
 						}
 					}
-
-					EventHooks.finalizeMobSpawn(mob, level, level.getCurrentDifficultyAt(oldEntity.blockPosition()), EntitySpawnReason.CONVERSION, null);
 				}
 
 				oldEntity.level().addFreshEntity(newEntity);
@@ -366,8 +324,8 @@ public class EntityUtil {
 				}
 			}
 
-			if (newEntity instanceof LivingEntity living) EventHooks.onLivingConvert(oldEntity, living);
-			level.playSound(null, newEntity.blockPosition(), TFSounds.POWDER_USE.get(), newEntity.getSoundSource());
+			// NeoForge's onLivingConvert event has no Fabric equivalent
+			level.playSound(null, newEntity.blockPosition(), TFSounds.POWDER_USE.value(), newEntity.getSoundSource());
 			return true;
 		}
 		return false;

--- a/src/main/java/twilightforest/util/entities/EntityUtil.java
+++ b/src/main/java/twilightforest/util/entities/EntityUtil.java
@@ -273,7 +273,6 @@ public class EntityUtil {
 							}
 						}
 					}
-					// vanilla conversion initialisation (NeoForge's finalizeMobSpawn hook removed)
 					mob.finalizeSpawn(level, level.getCurrentDifficultyAt(oldEntity.blockPosition()), EntitySpawnReason.CONVERSION, null);
 				}
 
@@ -326,7 +325,6 @@ public class EntityUtil {
 				}
 			}
 
-			// NeoForge's onLivingConvert event has no Fabric equivalent
 			level.playSound(null, newEntity.blockPosition(), TFSounds.POWDER_USE.value(), newEntity.getSoundSource());
 			return true;
 		}

--- a/src/main/java/twilightforest/util/entities/EntityUtil.java
+++ b/src/main/java/twilightforest/util/entities/EntityUtil.java
@@ -1,6 +1,7 @@
 package twilightforest.util.entities;
 
 import com.google.common.collect.Lists;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
@@ -255,11 +256,13 @@ public class EntityUtil {
 		if (!(oldEntity.level() instanceof ServerLevel level)) return false;
 		var newEntity = newType.create(level, EntitySpawnReason.CONVERSION);
 		if (newEntity == null) return false;
+		boolean firedMobConversion = false;
 		// NeoForge's canLivingConvert event has no Fabric equivalent, so conversion always proceeds
 		{
 			var passengerSave = oldEntity.getPassengers();
 			if (oldEntity instanceof Mob mob && newEntity instanceof Mob newMob) {
 				newEntity = mob.convertTo((EntityType<? extends Mob>) newMob.getType(), ConversionParams.single(newMob, true, true), (ConversionParams.AfterConversion) _ -> {});
+				firedMobConversion = true;
 			} else {
 				newEntity.copyPosition(oldEntity);
 
@@ -323,6 +326,10 @@ public class EntityUtil {
 				for (var entity : passengerSave) {
 					entity.startRiding(newEntity, true, false);
 				}
+			}
+
+			if (newEntity instanceof Mob mob && oldEntity instanceof Mob oldMob && !firedMobConversion) {
+				ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(oldMob, mob, ConversionParams.single(mob, true, true));
 			}
 
 			level.playSound(null, newEntity.blockPosition(), TFSounds.POWDER_USE.value(), newEntity.getSoundSource());

--- a/src/main/java/twilightforest/util/entities/EntityUtil.java
+++ b/src/main/java/twilightforest/util/entities/EntityUtil.java
@@ -88,7 +88,7 @@ public class EntityUtil {
 
 	@Nullable
 	public static SoundEvent getDeathSound(LivingEntity living) {
-		return ((twilightforest.asm.mixin.coremod.LivingEntityGetDeathSoundAccessor) living).twilightforest$invokeGetDeathSound();
+		return ((twilightforest.asm.mixin.LivingEntityGetDeathSoundAccessor) living).twilightforest$invokeGetDeathSound();
 	}
 
 	public static void killLavaAround(Entity entity) {
@@ -273,6 +273,8 @@ public class EntityUtil {
 							}
 						}
 					}
+					// vanilla conversion initialisation (NeoForge's finalizeMobSpawn hook removed)
+					mob.finalizeSpawn(level, level.getCurrentDifficultyAt(oldEntity.blockPosition()), EntitySpawnReason.CONVERSION, null);
 				}
 
 				oldEntity.level().addFreshEntity(newEntity);

--- a/src/main/java/twilightforest/util/entities/EntityUtil.java
+++ b/src/main/java/twilightforest/util/entities/EntityUtil.java
@@ -64,6 +64,7 @@ public class EntityUtil {
 		float hardness = state.getDestroySpeed(world, pos);
 		return hardness >= 0f && hardness < 50f && !state.isAir()
 			&& !(world.getBlockEntity(pos) instanceof Container)
+			&& state.getBlock().carminite$canEntityDestroy(state, world, pos, entity)
 			&& (/* rude type limit */!(entity instanceof LivingEntity));
 	}
 

--- a/src/main/resources/twilightforest.classtweaker
+++ b/src/main/resources/twilightforest.classtweaker
@@ -274,7 +274,6 @@ accessible method net/minecraft/client/particle/SuspendedTownParticle <init> (Ln
 extendable method net/minecraft/client/model/Model renderToBuffer (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V
 
 # EntityUtil (direct calls instead of NeoForge ObfuscationReflectionHelper)
-accessible method net/minecraft/world/entity/LivingEntity getDeathSound ()Lnet/minecraft/sounds/SoundEvent;
 accessible method net/minecraft/world/entity/decoration/HangingEntity setDirection (Lnet/minecraft/core/Direction;)V
 
 # Enum Extensions

--- a/src/main/resources/twilightforest.classtweaker
+++ b/src/main/resources/twilightforest.classtweaker
@@ -273,6 +273,10 @@ accessible method net/minecraft/client/particle/SuspendedTownParticle <init> (Ln
 # NoopModel and other TF models keep their renderToBuffer overrides (matching NeoForge)
 extendable method net/minecraft/client/model/Model renderToBuffer (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V
 
+# EntityUtil (direct calls instead of NeoForge ObfuscationReflectionHelper)
+accessible method net/minecraft/world/entity/LivingEntity getDeathSound ()Lnet/minecraft/sounds/SoundEvent;
+accessible method net/minecraft/world/entity/decoration/HangingEntity setDirection (Lnet/minecraft/core/Direction;)V
+
 # Enum Extensions
 extend-enum net/minecraft/world/damagesource/DamageEffects TWILIGHTFOREST_PINCH
 extend-enum net/minecraft/world/item/Rarity TWILIGHTFOREST_TWILIGHT
@@ -282,4 +286,3 @@ extend-enum net/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifi
 extend-enum net/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifier TWILIGHTFOREST_DARK_FOREST_CENTER
 extend-enum net/minecraft/world/level/biome/BiomeSpecialEffects$GrassColorModifier TWILIGHTFOREST_SPOOKY_FOREST
 extend-enum net/minecraft/world/item/ItemDisplayContext TWILIGHTFOREST_JARRED
-

--- a/src/main/resources/twilightforest.mixins.json
+++ b/src/main/resources/twilightforest.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_25",
   "mixins": [
     "ServerPlayerGameModeMixin",
+    "coremod.LivingEntityGetDeathSoundAccessor",
     "enums.DamageEffectsMixin",
     "enums.GrassColorModifierMixin",
     "enums.ItemDisplayContextMixin",

--- a/src/main/resources/twilightforest.mixins.json
+++ b/src/main/resources/twilightforest.mixins.json
@@ -5,7 +5,7 @@
   "compatibilityLevel": "JAVA_25",
   "mixins": [
     "ServerPlayerGameModeMixin",
-    "coremod.LivingEntityGetDeathSoundAccessor",
+    "LivingEntityGetDeathSoundAccessor",
     "enums.DamageEffectsMixin",
     "enums.GrassColorModifierMixin",
     "enums.ItemDisplayContextMixin",


### PR DESCRIPTION
- Replace NeoForge ObfuscationReflectionHelper with direct calls to getDeathSound/setDirection (widened via the classtweaker)
- Block.canEntityDestroy is gone; drop that check
- Remove the NeoForge EventHooks calls (onEntityDestroyBlock, canLivingConvert, finalizeMobSpawn, onLivingConvert) which have no Fabric equivalent; conversion now always proceeds
- TFSounds.POWDER_USE.get() -> value()