### PR TITLE
Sync LockedBiomeToast with upstream's 26.1 adaptation

### DIFF
--- a/src/main/java/twilightforest/client/LockedBiomeToast.java
+++ b/src/main/java/twilightforest/client/LockedBiomeToast.java
@@ -1,25 +1,42 @@
 package twilightforest.client;
 
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.toasts.Toast;
-import net.minecraft.client.gui.components.toasts.ToastComponent;
+import net.minecraft.client.gui.components.toasts.ToastManager;
+import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
 
-public record LockedBiomeToast(ItemStack item) implements Toast {
+public class LockedBiomeToast implements Toast {
 
 	private static final Component TITLE = Component.translatable("misc.twilightforest.biome_locked");
 	private static final Component DESCRIPTION = Component.translatable("misc.twilightforest.biome_locked_2");
 	private static final Identifier BACKGROUND_SPRITE = Identifier.withDefaultNamespace("toast/advancement");
 
-	@Override
-	public Visibility render(GuiGraphics graphics, ToastComponent component, long timer) {
-		graphics.blitSprite(BACKGROUND_SPRITE, 0, 0, this.width(), this.height());
-		graphics.renderFakeItem(this.item(), 6, 8);
-		graphics.drawString(component.getMinecraft().font, TITLE, 25, 7, -256, false);
-		graphics.drawString(component.getMinecraft().font, DESCRIPTION, 25, 18, 16777215, false);
+	private final ItemStack item;
+	private Toast.Visibility wantedVisibility = Toast.Visibility.HIDE;
 
-		return timer >= 10000L ? Toast.Visibility.HIDE : Toast.Visibility.SHOW;
+	public LockedBiomeToast(ItemStack item) {
+		this.item = item;
+	}
+
+	@Override
+	public void extractRenderState(GuiGraphicsExtractor graphics, Font font, long fullyVisibleForMs) {
+		graphics.blitSprite(RenderPipelines.GUI_TEXTURED, BACKGROUND_SPRITE, 0, 0, this.width(), this.height());
+		graphics.fakeItem(this.item, 6, 8);
+		graphics.text(font, TITLE, 25, 7, -256, false);
+		graphics.text(font, DESCRIPTION, 25, 18, 16777215, false);
+	}
+
+	@Override
+	public Visibility getWantedVisibility() {
+		return this.wantedVisibility;
+	}
+
+	@Override
+	public void update(ToastManager manager, long fullyVisibleForMs) {
+		this.wantedVisibility = fullyVisibleForMs >= 10000L ? Toast.Visibility.HIDE : Toast.Visibility.SHOW;
 	}
 }


### PR DESCRIPTION
Toast now uses GuiGraphicsExtractor/ToastManager with extractRenderState/getWantedVisibility/update instead of the old render(ToastComponent) API.