### PR TITLE
Adapt EntityHooks to 26.1/Fabric APIs

### DIFF
--- a/src/main/java/twilightforest/asm/hooks/coremod/EntityHooks.java
+++ b/src/main/java/twilightforest/asm/hooks/coremod/EntityHooks.java
@@ -60,6 +60,18 @@ public class EntityHooks {
 		return prior && !mob.hasAttached(TFDataAttachments.LEASH_PATHFINDER_OVERRIDE);
 	}
 
+	// [Fabric] Kept (disabled) until the coremod/transformers are ported; the
+	// FluidType-based check has no 26.1 equivalent yet.
+//	public static BiPredicate<FluidType, Double> unrestrainedSwimPredicate(BiPredicate<FluidType, Double> o, LivingEntity livingEntity) {
+//		return (fluidType, height) -> {
+//			FluidState fs = livingEntity.level().getFluidState(livingEntity.blockPosition());
+//			boolean oResult = o.test(fluidType, height);
+//			if (fluidType != NeoForgeMod.WATER_TYPE.value())
+//				return oResult;
+//			return unrestrainedSprintingInWater(oResult, livingEntity);
+//		};
+//	}
+
 	/**
 	 * {@link twilightforest.asm.transformers.entity.UnrestrainedBlockSpeedAndJumpFactorTransformer} <p/>
 	 *

--- a/src/main/java/twilightforest/asm/hooks/coremod/EntityHooks.java
+++ b/src/main/java/twilightforest/asm/hooks/coremod/EntityHooks.java
@@ -7,14 +7,11 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.neoforge.common.NeoForgeMod;
-import net.neoforged.neoforge.fluids.FluidType;
 import org.jetbrains.annotations.Nullable;
 import twilightforest.init.TFDataAttachments;
 import twilightforest.init.custom.TravellersModifiersManager;
 import twilightforest.item.travellers_gear.TravellersGearLogic;
 
-import java.util.function.BiPredicate;
 
 @SuppressWarnings({"JavadocReference", "unused"})
 public class EntityHooks {
@@ -34,7 +31,7 @@ public class EntityHooks {
 			return o;
 
 		boolean isWaterWalking = TravellersGearLogic.isBelowMaxWaterWalkingSubmergedHeight(livingEntity) && !livingEntity.isShiftKeyDown();
-		if (livingEntity.getFluidTypeHeight(NeoForgeMod.WATER_TYPE.value()) > 0 && isWaterWalking && livingEntity.level().getGameTime() % 3 == 1)
+		if (livingEntity.isInWater() && isWaterWalking && livingEntity.level().getGameTime() % 3 == 1)
 			TravellersGearLogic.waterWalkingSplashEffect(livingEntity);
 		return isWaterWalking;
 	}
@@ -53,23 +50,6 @@ public class EntityHooks {
 	}
 
 	/**
-	 * {@link twilightforest.asm.transformers.entity.WaterSprintTransformer}<p/>
-	 * <p>
-	 * Injection Point:<br/>
-	 * {@link net.minecraft.client.player.LocalPlayer#aiStep()}
-	 * Targets: {@link net.neoforged.neoforge.common.extensions.IEntityExtension#isInFluidType(java.util.function.BiPredicate<net.neoforged.neoforge.fluids.FluidType, Double>)}
-	 */
-	public static BiPredicate<FluidType, Double> unrestrainedSwimPredicate(BiPredicate<FluidType, Double> o, LivingEntity livingEntity) {
-		return (fluidType, height) -> {
-			FluidState fs = livingEntity.level().getFluidState(livingEntity.blockPosition());
-			boolean oResult = o.test(fluidType, height);
-			if (fluidType != NeoForgeMod.WATER_TYPE.value())
-				return oResult;
-			return unrestrainedSprintingInWater(oResult, livingEntity);
-		};
-	}
-
-	/**
 	 * {@link twilightforest.asm.transformers.entity.PathFinderUnrestrainedByLeashTransformer} <p/>
 	 *
 	 * Injection Point:<br/>
@@ -77,7 +57,7 @@ public class EntityHooks {
 	 * Targets: IRETURN
 	 */
 	public static boolean overrideStayCloseToHolder(boolean prior, PathfinderMob mob) {
-		return prior && !mob.hasData(TFDataAttachments.LEASH_PATHFINDER_OVERRIDE);
+		return prior && !mob.hasAttached(TFDataAttachments.LEASH_PATHFINDER_OVERRIDE);
 	}
 
 	/**

--- a/src/main/resources/twilightforest.classtweaker
+++ b/src/main/resources/twilightforest.classtweaker
@@ -276,6 +276,9 @@ extendable method net/minecraft/client/model/Model renderToBuffer (Lcom/mojang/b
 # EntityUtil (direct calls instead of NeoForge ObfuscationReflectionHelper)
 accessible method net/minecraft/world/entity/decoration/HangingEntity setDirection (Lnet/minecraft/core/Direction;)V
 
+# EntityHooks (resets stuck speed for the unrestrained modifier)
+accessible field net/minecraft/world/entity/Entity stuckSpeedMultiplier Lnet/minecraft/world/phys/Vec3;
+
 # Enum Extensions
 extend-enum net/minecraft/world/damagesource/DamageEffects TWILIGHTFOREST_PINCH
 extend-enum net/minecraft/world/item/Rarity TWILIGHTFOREST_TWILIGHT


### PR DESCRIPTION
- FluidType/NeoForgeMod APIs are gone: use isInWater() for the water walking splash check and drop the unrestrainedSwimPredicate hook (its isInFluidType injection point no longer exists)
- mob.hasData -> hasAttached (Fabric attachment API)
- widen Entity.stuckSpeedMultiplier via the classtweaker