### PR TITLE
Adapt MultipartHooks to Fabric

### DIFF
--- a/src/main/java/twilightforest/asm/hooks/coremod/MultipartHooks.java
+++ b/src/main/java/twilightforest/asm/hooks/coremod/MultipartHooks.java
@@ -18,22 +18,22 @@ public class MultipartHooks {
 	private static final MultipartEntityUtil multipartEntityUtil = MultipartEntityUtil.INSTANCE;
 
 	/**
-	 * {@link twilightforest.asm.transformers.multipart.ResolveEntitiesForRendereringTransformer}<p/>
+	 * twilightforest.asm.transformers.multipart.ResolveEntitiesForRendereringTransformer<p/>
 	 *
 	 * Injection Point:<br/>
-	 * {@link net.minecraft.client.renderer.LevelRenderer#renderLevel(DeltaTracker, boolean, Camera, GameRenderer, LightTexture, Matrix4f, Matrix4f)}<br/>
-	 * [Targets: {@link net.minecraft.client.multiplayer.ClientLevel#entitiesForRendering}]
+	 * net.minecraft.client.renderer.LevelRenderer#renderLevel(DeltaTracker, boolean, Camera, GameRenderer, LightTexture, Matrix4f, Matrix4f)<br/>
+	 * [Targets: net.minecraft.client.multiplayer.ClientLevel#entitiesForRendering]
 	 */
 	public static Iterator<Entity> resolveEntitiesForRendering(Iterator<Entity> iter) {
 		return multipartEntityUtil.injectTFPartEntities(iter);
 	}
 
 	/**
-	 * {@link twilightforest.asm.transformers.multipart.ResolveEntityRendererTransformer}<p/>
+	 * twilightforest.asm.transformers.multipart.ResolveEntityRendererTransformer<p/>
 	 *
 	 * Injection Point:<br/>
-	 * {@link net.minecraft.client.renderer.entity.EntityRenderDispatcher#getRenderer(Entity)}<br/>
-	 * Targets: {@link net.minecraft.client.renderer.entity.EntityRenderDispatcher#renderers}
+	 * net.minecraft.client.renderer.entity.EntityRenderDispatcher#getRenderer(Entity)<br/>
+	 * Targets: net.minecraft.client.renderer.entity.EntityRenderDispatcher#renderers
 	 */
 	@Nullable
 	public static EntityRenderer<?, ?> resolveEntityRenderer(@Nullable EntityRenderer<?, ?> renderer, Entity entity) {
@@ -41,10 +41,10 @@ public class MultipartHooks {
 	}
 
 	/**
-	 * {@link SendDirtyEntityDataTransformer}<p/>
+	 * SendDirtyEntityDataTransformer<p/>
 	 *
 	 * Injection Point:<br/>
-	 * {@link net.minecraft.server.level.ServerEntity#sendDirtyEntityData}
+	 * net.minecraft.server.level.ServerEntity#sendDirtyEntityData
 	 */
 	public static Entity sendDirtyEntityData(Entity entity) {
 		return multipartEntityUtil.sendDirtyMultipartEntityData(entity);

--- a/src/main/java/twilightforest/asm/hooks/coremod/MultipartHooks.java
+++ b/src/main/java/twilightforest/asm/hooks/coremod/MultipartHooks.java
@@ -3,13 +3,10 @@ package twilightforest.asm.hooks.coremod;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.GameRenderer;
-import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.world.entity.Entity;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
-import tamaized.beanification.Autowired;
-import twilightforest.asm.transformers.multipart.SendDirtyEntityDataTransformer;
 import twilightforest.util.multiparts.MultipartEntityUtil;
 
 import java.util.Iterator;
@@ -17,8 +14,8 @@ import java.util.Iterator;
 @SuppressWarnings({"JavadocReference", "unused"})
 public class MultipartHooks {
 
-	@Autowired
-	private static MultipartEntityUtil multipartEntityUtil;
+	
+	private static final MultipartEntityUtil multipartEntityUtil = MultipartEntityUtil.INSTANCE;
 
 	/**
 	 * {@link twilightforest.asm.transformers.multipart.ResolveEntitiesForRendereringTransformer}<p/>
@@ -39,7 +36,7 @@ public class MultipartHooks {
 	 * Targets: {@link net.minecraft.client.renderer.entity.EntityRenderDispatcher#renderers}
 	 */
 	@Nullable
-	public static EntityRenderer<?> resolveEntityRenderer(@Nullable EntityRenderer<?> renderer, Entity entity) {
+	public static EntityRenderer<?, ?> resolveEntityRenderer(@Nullable EntityRenderer<?, ?> renderer, Entity entity) {
 		return multipartEntityUtil.tryLookupTFPartRenderer(renderer, entity);
 	}
 


### PR DESCRIPTION
- Drop the beanification `@Autowired`, use `MultipartEntityUtil.INSTANCE`
- `EntityRenderer<?>` -> `EntityRenderer<?, ?>` (two type params in 26.1)
- Remove imports for classes that only appear in Javadoc (`LightTexture`)
  or no longer exist (`twilightforest.asm.transformers.multipart`)