### PR TITLE
Replace beanification with manual singleton in ArmorUtil/ArmorHooks

### DIFF
--- a/src/main/java/twilightforest/asm/hooks/coremod/ArmorHooks.java
+++ b/src/main/java/twilightforest/asm/hooks/coremod/ArmorHooks.java
@@ -8,15 +8,13 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import tamaized.beanification.Autowired;
 import twilightforest.init.TFDataComponents;
 import twilightforest.util.ArmorUtil;
 
 @SuppressWarnings({"JavadocReference", "unused"})
 public class ArmorHooks {
 
-	@Autowired
-	private static ArmorUtil armorUtil;
+	private static final ArmorUtil armorUtil = ArmorUtil.INSTANCE;
 
 	/**
 	 * {@link twilightforest.asm.transformers.armor.ArmorVisibilityRenderingTransformer}<p/>

--- a/src/main/java/twilightforest/util/ArmorUtil.java
+++ b/src/main/java/twilightforest/util/ArmorUtil.java
@@ -4,11 +4,11 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import tamaized.beanification.Component;
 import twilightforest.init.TFDataComponents;
 
-@Component
+
 public class ArmorUtil {
+	public static final ArmorUtil INSTANCE = new ArmorUtil();
 	public float getShroudedArmorPercentage(LivingEntity entity) {
 		int shroudedArmor = 0;
 		int armorSlots = 0;


### PR DESCRIPTION
ArmorUtil gets a static INSTANCE and ArmorHooks uses it directly instead of Autowired.