### PR TITLE
Adapt HelmetCrab model/rendering to 26.1

### DIFF
--- a/src/main/java/twilightforest/client/model/entity/HelmetCrabModel.java
+++ b/src/main/java/twilightforest/client/model/entity/HelmetCrabModel.java
@@ -49,6 +49,10 @@ public class HelmetCrabModel extends EntityModel<HelmetCrabRenderState> {
 		this.leftLeg2 = this.crab.getChild("left_leg_2");
 	}
 
+	public ModelPart getHelmet() {
+		return this.helmet;
+	}
+
 	public static LayerDefinition create() {
 		MeshDefinition meshdefinition = new MeshDefinition();
 		PartDefinition partdefinition = meshdefinition.getRoot();
@@ -146,13 +150,6 @@ public class HelmetCrabModel extends EntityModel<HelmetCrabRenderState> {
 			PartPose.offsetAndRotation(3.0F, 1.0F, -2.0F, 0.0F, 0.2792527F, 0.1919862F));
 
 		return LayerDefinition.create(meshdefinition, 64, 32);
-	}
-
-	@Override
-	public void renderToBuffer(PoseStack stack, VertexConsumer consumer, int light, int overlay, int color) {
-		this.crab.render(stack, consumer, light, overlay, color);
-		//no red overlay on the helmet
-		this.helmet.render(stack, consumer, light, OverlayTexture.NO_OVERLAY, color);
 	}
 
 	@Override

--- a/src/main/java/twilightforest/client/model/entity/HelmetCrabModel.java
+++ b/src/main/java/twilightforest/client/model/entity/HelmetCrabModel.java
@@ -53,6 +53,13 @@ public class HelmetCrabModel extends EntityModel<HelmetCrabRenderState> {
 		return this.helmet;
 	}
 
+	@Override
+	public void renderToBuffer(PoseStack stack, VertexConsumer consumer, int light, int overlay, int color) {
+		this.crab.render(stack, consumer, light, overlay, color);
+		//no red overlay on the helmet
+		this.helmet.render(stack, consumer, light, OverlayTexture.NO_OVERLAY, color);
+	}
+
 	public static LayerDefinition create() {
 		MeshDefinition meshdefinition = new MeshDefinition();
 		PartDefinition partdefinition = meshdefinition.getRoot();

--- a/src/main/java/twilightforest/client/renderer/entity/HelmetCrabRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/entity/HelmetCrabRenderer.java
@@ -1,7 +1,13 @@
 package twilightforest.client.renderer.entity;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.MobRenderer;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.Identifier;
 import twilightforest.TFMain;
 import twilightforest.client.model.TFModelLayers;
@@ -25,9 +31,27 @@ public class HelmetCrabRenderer extends MobRenderer<HelmetCrab, HelmetCrabRender
 	@Override
 	public void extractRenderState(HelmetCrab entity, HelmetCrabRenderState state, float partialTicks) {
 		super.extractRenderState(entity, state, partialTicks);
+		state.partialTick = partialTicks;
 		state.helmetRot = state.getHelmetRotation(entity, partialTicks);
 		state.id = entity.getId();
 		state.blue = entity.isBlue();
+	}
+
+	@Override
+	public void submit(HelmetCrabRenderState state, PoseStack stack, SubmitNodeCollector collector, CameraRenderState camera) {
+		// Model.renderToBuffer is final in 26.1, so render the helmet separately
+		// without the red damage overlay (as the old override did)
+		ModelPart helmet = this.model.getHelmet();
+		helmet.visible = false;
+		super.submit(state, stack, collector, camera);
+		helmet.visible = true;
+		RenderType renderType = this.model.renderType(this.getTextureLocation(state));
+		collector.submitCustomGeometry(stack, renderType, (pose, consumer) -> {
+			stack.pushPose();
+			stack.last().set(pose);
+			helmet.render(stack, consumer, state.lightCoords, OverlayTexture.NO_OVERLAY, state.outlineColor);
+			stack.popPose();
+		});
 	}
 
 	@Override

--- a/src/main/java/twilightforest/client/state/entity/HelmetCrabRenderState.java
+++ b/src/main/java/twilightforest/client/state/entity/HelmetCrabRenderState.java
@@ -6,6 +6,7 @@ import twilightforest.entity.monster.HelmetCrab;
 
 public class HelmetCrabRenderState extends LivingEntityRenderState {
 	public float helmetRot;
+	public float partialTick;
 	public int id;
 	public boolean blue;
 

--- a/src/main/resources/twilightforest.classtweaker
+++ b/src/main/resources/twilightforest.classtweaker
@@ -272,6 +272,7 @@ accessible method net/minecraft/client/particle/SuspendedTownParticle <init> (Ln
 
 # NoopModel and other TF models keep their renderToBuffer overrides (matching NeoForge)
 extendable method net/minecraft/client/model/Model renderToBuffer (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V
+extendable method net/minecraft/client/model/Model renderToBuffer (Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;IIII)V
 
 # EntityUtil (direct calls instead of NeoForge ObfuscationReflectionHelper)
 accessible method net/minecraft/world/entity/decoration/HangingEntity setDirection (Lnet/minecraft/core/Direction;)V


### PR DESCRIPTION
- Model.renderToBuffer is final in 26.1: drop the override, expose the helmet part and render it separately in the renderer without the red damage overlay (via submitCustomGeometry), preserving the old behaviour
- HelmetCrabRenderState carries partialTick (set in extractRenderState) instead of reading it in setupAnim