### PR TITLE
Port ClientGameEvents and TravellersClientEvents to 26.1/Fabric

### DIFF
--- a/src/main/java/twilightforest/TFClient.java
+++ b/src/main/java/twilightforest/TFClient.java
@@ -2,6 +2,11 @@ package twilightforest;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import twilightforest.client.event.ClientGameEvents;
+import twilightforest.client.event.CloudEvents;
+import twilightforest.client.event.LockedBiomeToastHandler;
+import twilightforest.client.renderer.TFSkyRenderer;
+import twilightforest.item.mapdata.MapDataManager;
 import twilightforest.network.*;
 
 public final class TFClient implements ClientModInitializer {
@@ -9,6 +14,12 @@ public final class TFClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		registerPackets();
+
+		CloudEvents.init();
+		LockedBiomeToastHandler.init();
+		TFSkyRenderer.init();
+		MapDataManager.init();
+		ClientGameEvents.init();
 	}
 
 	private static void registerPackets() {

--- a/src/main/java/twilightforest/asm/mixin/AbstractClientPlayerFovMixin.java
+++ b/src/main/java/twilightforest/asm/mixin/AbstractClientPlayerFovMixin.java
@@ -1,0 +1,33 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import twilightforest.item.EnderBowItem;
+import twilightforest.item.IceBowItem;
+import twilightforest.item.SeekerBowItem;
+import twilightforest.item.TripleBowItem;
+
+/**
+ * Recreates NeoForge's ComputeFovModifierEvent handling: twilight bows zoom the
+ * FOV while drawn, mirroring the vanilla behaviour in getFieldOfViewModifier.
+ */
+@Mixin(AbstractClientPlayer.class)
+public class AbstractClientPlayerFovMixin {
+
+	@Inject(method = "getFieldOfViewModifier(ZF)F", at = @At("RETURN"), cancellable = true)
+	private void twilightforest$bowFovModifier(boolean usingFOV, float partialTick, CallbackInfoReturnable<Float> cir) {
+		AbstractClientPlayer player = (AbstractClientPlayer) (Object) this;
+		ItemStack useItem = player.getUseItem();
+		if (player.isUsingItem() && (useItem.getItem() instanceof TripleBowItem || useItem.getItem() instanceof EnderBowItem || useItem.getItem() instanceof IceBowItem || useItem.getItem() instanceof SeekerBowItem)) {
+			float f = player.getTicksUsingItem() / 20.0F;
+			f = f > 1.0F ? 1.0F : f * f;
+			cir.setReturnValue((float) Mth.lerp(Minecraft.getInstance().options.fovEffectScale().get(), 1.0F, cir.getReturnValue() * (1.0F - f * 0.15F)));
+		}
+	}
+}

--- a/src/main/java/twilightforest/asm/mixin/BossHealthOverlayMixin.java
+++ b/src/main/java/twilightforest/asm/mixin/BossHealthOverlayMixin.java
@@ -1,0 +1,26 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.BossHealthOverlay;
+import net.minecraft.world.BossEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import twilightforest.entity.boss.bar.ClientTFBossBar;
+
+/**
+ * Recreates NeoForge's CustomizeGuiOverlayEvent.BossEventProgress handling:
+ * twilight boss bars use their custom colour rendering instead of the default.
+ */
+@Mixin(BossHealthOverlay.class)
+public class BossHealthOverlayMixin {
+
+	@Inject(method = "extractBar(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IILnet/minecraft/world/BossEvent;)V", at = @At("HEAD"), cancellable = true)
+	private void twilightforest$renderCustomBossBar(GuiGraphicsExtractor extractor, int x, int y, BossEvent event, CallbackInfo ci) {
+		if (event instanceof ClientTFBossBar bossBar) {
+			bossBar.renderBossBar(extractor, x, y);
+			ci.cancel();
+		}
+	}
+}

--- a/src/main/java/twilightforest/asm/mixin/CameraShakeMixin.java
+++ b/src/main/java/twilightforest/asm/mixin/CameraShakeMixin.java
@@ -1,0 +1,40 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.Mth;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import twilightforest.client.event.ClientGameEvents;
+import twilightforest.config.TFConfig;
+
+/**
+ * Recreates NeoForge's ViewportEvent.ComputeCameraAngles handling for the
+ * beanstalk earthquake screen shake.
+ */
+@Mixin(Camera.class)
+public class CameraShakeMixin {
+
+	@Shadow
+	@Final
+	private org.joml.Quaternionf rotation;
+
+	@Inject(method = "setRotation(FF)V", at = @At("TAIL"))
+	private void twilightforest$applyShake(float yaw, float pitch, CallbackInfo ci) {
+		if (!ClientGameEvents.shouldShakeCamera()) return;
+		Minecraft minecraft = Minecraft.getInstance();
+		float intensity = ClientGameEvents.consumeShakeIntensity();
+		if (minecraft.player == null) return;
+		float partialTick = minecraft.getDeltaTracker().getGameTimeDeltaPartialTick(true);
+		float yawDelta = (minecraft.player.getRandom().nextFloat() * 2.0F - 1.0F) * intensity;
+		float pitchDelta = (minecraft.player.getRandom().nextFloat() * 2.5F - 1.25F) * intensity;
+		float rollDelta = (minecraft.player.getRandom().nextFloat() * 2.0F - 1.0F) * intensity;
+		float yawDeg = (yaw + Mth.lerp(partialTick, 0.0F, yawDelta)) * Mth.DEG_TO_RAD;
+		float pitchDeg = (pitch + Mth.lerp(partialTick, 0.0F, pitchDelta)) * Mth.DEG_TO_RAD;
+		this.rotation.rotationYXZ(yawDeg, pitchDeg, rollDelta * Mth.DEG_TO_RAD);
+	}
+}

--- a/src/main/java/twilightforest/asm/mixin/GuiVignetteMixin.java
+++ b/src/main/java/twilightforest/asm/mixin/GuiVignetteMixin.java
@@ -1,0 +1,24 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.gui.Gui;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import twilightforest.init.TFDimension;
+
+/**
+ * Recreates NeoForge's RenderFrameEvent.Pre handling for the twilight forest:
+ * the vignette is never shown in the twilight dimension.
+ */
+@Mixin(Gui.class)
+public class GuiVignetteMixin {
+
+	@Inject(method = "updateVignetteBrightness(Lnet/minecraft/world/entity/Entity;)V", at = @At("TAIL"))
+	private void twilightforest$disableVignette(Entity entity, CallbackInfo ci) {
+		if (TFDimension.DIMENSION_KEY.equals(entity.level().dimension())) {
+			((Gui) (Object) this).vignetteBrightness = 0.0F;
+		}
+	}
+}

--- a/src/main/java/twilightforest/client/event/ClientGameEvents.java
+++ b/src/main/java/twilightforest/client/event/ClientGameEvents.java
@@ -132,6 +132,10 @@ public class ClientGameEvents {
 
 			BugModelAnimationHelper.animate();
 
+			if (mc.player != null && HostileMountEvents.isRidingUnfriendly(mc.player)) {
+				mc.gui.setOverlayMessage(Component.empty(), false);
+			}
+
 			if (mc.level != null) {
 				if (mc.level.getSkyFlashTime() > 0) {
 					MagicPaintingRenderer.lastLightning = mc.level.getGameTime();
@@ -190,8 +194,7 @@ public class ClientGameEvents {
 		}
 	}
 
-	private static boolean renderGiantBlockOutlines(LevelRenderContext context, BlockOutlineRenderState outline) {
-		BlockPos pos = outline.pos();
+	private static boolean renderGiantBlockOutlines(LevelRenderContext context, BlockOutlineRenderState outline) {		BlockPos pos = outline.pos();
 		BlockState state = context.gameRenderer().getMainCamera().entity().level().getBlockState(pos);
 
 		if (state.getBlock() instanceof MiniatureStructureBlock) {
@@ -209,5 +212,15 @@ public class ClientGameEvents {
 			return false;
 		}
 		return true;
+	}
+
+	public static boolean shouldShakeCamera() {
+		return shakeIntensity > 0.0F && TFConfig.firstPersonEffects && !Minecraft.getInstance().isPaused() && Minecraft.getInstance().player != null;
+	}
+
+	public static float consumeShakeIntensity() {
+		float intensity = shakeIntensity;
+		shakeIntensity = 0.0F;
+		return intensity;
 	}
 }

--- a/src/main/java/twilightforest/client/event/ClientGameEvents.java
+++ b/src/main/java/twilightforest/client/event/ClientGameEvents.java
@@ -1,61 +1,56 @@
 package twilightforest.client.event;
 
 import com.ibm.icu.text.RuleBasedNumberFormat;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.*;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
+import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderContext;
+import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.SplashRenderer;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
-import net.minecraft.client.model.HeadedModel;
-import net.minecraft.client.model.HumanoidModel;
-import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.LevelRenderer;
-import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.ShapeRenderer;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.client.renderer.state.level.BlockOutlineRenderState;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.sounds.Music;
-import net.minecraft.sounds.Musics;
+import net.minecraft.util.ARGB;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.*;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.WrittenBookItem;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.fml.ModList;
-import net.neoforged.neoforge.client.event.*;
-import net.neoforged.neoforge.client.gui.VanillaGuiLayers;
-import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.event.entity.player.ItemTooltipEvent;
-import tamaized.beanification.PostConstruct;
 import twilightforest.TFMain;
-import tamaized.beanification.Autowired;
 import twilightforest.block.GiantBlock;
 import twilightforest.block.MiniatureStructureBlock;
 import twilightforest.block.entity.GrowingBeanstalkBlockEntity;
-import twilightforest.client.*;
-import twilightforest.client.renderer.TFSkyRenderer;
+import twilightforest.client.BugModelAnimationHelper;
+import twilightforest.client.EntityCache;
 import twilightforest.client.renderer.entity.MagicPaintingRenderer;
-import twilightforest.compat.curios.CuriosCompat;
 import twilightforest.config.TFConfig;
-import twilightforest.item.mapdata.MapDataManager;
-import twilightforest.tags.TFItemTags;
-import twilightforest.entity.boss.bar.ClientTFBossBar;
 import twilightforest.events.HostileMountEvents;
-import twilightforest.init.*;
-import twilightforest.item.*;
+import twilightforest.init.TFDataComponents;
+import twilightforest.item.GiantPickItem;
+import twilightforest.tags.TFItemTags;
 import twilightforest.util.HolderMatcher;
 
 import java.time.LocalDate;
@@ -64,138 +59,68 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 
-@tamaized.beanification.Component(dist = Dist.CLIENT)
 public class ClientGameEvents {
-	private final VoxelShape GIANT_BLOCK = Shapes.box(0.0D, 0.0D, 0.0D, 4.0D, 4.0D, 4.0D);
-	private final MutableComponent WIP_TEXT = Component.translatable("misc.twilightforest.wip").withStyle(ChatFormatting.RED);
-	private final MutableComponent EMPERORS_CLOTH_TOOLTIP = Component.translatable("item.twilightforest.emperors_cloth.desc").withStyle(ChatFormatting.GRAY);
+
+	private static final VoxelShape GIANT_BLOCK = Shapes.box(0.0D, 0.0D, 0.0D, 4.0D, 4.0D, 4.0D);
+	private static final MutableComponent WIP_TEXT = Component.translatable("misc.twilightforest.wip").withStyle(ChatFormatting.RED);
+	private static final MutableComponent EMPERORS_CLOTH_TOOLTIP = Component.translatable("item.twilightforest.emperors_cloth.desc").withStyle(ChatFormatting.GRAY);
 
 	public static int time = 0;
-	private float shakeIntensity = 0.0F;
+	private static float shakeIntensity = 0.0F;
 
-	private int aurora = 0;
-	private int lastAurora = 0;
+	private static int aurora = 0;
+	private static int lastAurora = 0;
 
-	@Autowired(dist = Dist.CLIENT)
-	private HolderMatcher holderMatcher;
+	private static final HolderMatcher holderMatcher = HolderMatcher.INSTANCE;
 
-	@PostConstruct
-	private void setup() {
-		NeoForge.EVENT_BUS.addListener(this::addCustomTooltips);
-		NeoForge.EVENT_BUS.addListener(this::clientTick);
-		NeoForge.EVENT_BUS.addListener(this::customizeSplashes);
-		NeoForge.EVENT_BUS.addListener(this::clearEntityRenderUtilMap);
-		NeoForge.EVENT_BUS.addListener(this::killVignette);
-		NeoForge.EVENT_BUS.addListener(this::removeHostileMountHealth);
-		NeoForge.EVENT_BUS.addListener(this::renderAurora);
-		NeoForge.EVENT_BUS.addListener(this::renderCustomBossbars);
-		NeoForge.EVENT_BUS.addListener(this::renderGiantBlockOutlines);
-		NeoForge.EVENT_BUS.addListener(this::setMusicInDimension);
-		NeoForge.EVENT_BUS.addListener(this::shakeCamera);
-		NeoForge.EVENT_BUS.addListener(this::translateBookAuthor);
-		NeoForge.EVENT_BUS.addListener(this::unrenderHeadWithTrophies);
-		NeoForge.EVENT_BUS.addListener(this::updateBowFOV);
+	public static void init() {
+		ScreenEvents.AFTER_INIT.register((minecraft, screen, width, height) -> {
+			customizeSplashes(screen);
+			ScreenEvents.remove(screen).register(s -> EntityCache.clearCache());
+		});
 
-		NeoForge.EVENT_BUS.addListener(CloudEvents::renderPrecipitation);
-		NeoForge.EVENT_BUS.addListener(CloudEvents::tickWeatherEffects);
+		ClientTickEvents.END_CLIENT_TICK.register(ClientGameEvents::clientTick);
 
-		NeoForge.EVENT_BUS.addListener(FogHandler::renderFog);
-		NeoForge.EVENT_BUS.addListener(FogHandler::unloadFog);
+		ItemTooltipCallback.EVENT.register((stack, context, flag, lines) -> {
+			addCustomTooltips(stack, lines);
+			translateBookAuthor(stack, lines);
+		});
 
-		NeoForge.EVENT_BUS.addListener(LockedBiomeToastHandler::tickLockedToastLogic);
+		LevelRenderEvents.BEFORE_BLOCK_OUTLINE.register(ClientGameEvents::renderGiantBlockOutlines);
 
-		NeoForge.EVENT_BUS.addListener(TFSkyRenderer::extractLevelRender);
+		HudElementRegistry.replaceElement(VanillaHudElements.MOUNT_HEALTH, previous -> (extractor, delta) -> {
+			if (!HostileMountEvents.isRidingUnfriendly(Minecraft.getInstance().player)) {
+				previous.extractRenderState(extractor, delta);
+			}
+		});
 
-		NeoForge.EVENT_BUS.addListener(MapDataManager::clearCache);
+		// TODO [Fabric] pending mixin/shader batches:
+		// - setMusicInDimension: mixin Minecraft#getSituationalMusic
+		// - renderAurora: needs TFShaders#AURORA ported to RenderPipeline
+		// - killVignette / shakeCamera / updateBowFOV / unrenderHeadWithTrophies / renderCustomBossbars: mixins
 	}
 
-	private void customizeSplashes(ScreenEvent.Init.Post event) {
-		if (event.getScreen() instanceof TitleScreen title) {
+	private static void customizeSplashes(Screen screen) {
+		if (screen instanceof TitleScreen title) {
 			SplashRenderer renderer = title.splash;
 			if (renderer != null) {
 				LocalDate date = LocalDate.now();
 				if (date.getMonth() == Month.AUGUST && date.getDayOfMonth() == 19) {
 					RuleBasedNumberFormat formatter = new RuleBasedNumberFormat(Locale.US, RuleBasedNumberFormat.ORDINAL);
-					renderer.splash = Component.literal(String.format("Happy %s birthday to the Twilight Forest!", formatter.format(date.getYear() - 2011)));
+					title.splash = new SplashRenderer(Component.literal(String.format("Happy %s birthday to the Twilight Forest!", formatter.format(date.getYear() - 2011))));
 				}
 			}
 		}
 	}
 
-	private void clearEntityRenderUtilMap(ScreenEvent.Closing event) {
-		EntityCache.clearCache();
-	}
-
-	private void setMusicInDimension(SelectMusicEvent event) {
-		Music music = event.getOriginalMusic();
-		if (Minecraft.getInstance().level != null && Minecraft.getInstance().player != null && (music == Musics.CREATIVE || music == Musics.UNDER_WATER) && TFDimension.isTwilightWorldOnClient(Minecraft.getInstance().level)) {
-			event.setMusic(Minecraft.getInstance().level.getBiomeManager().getNoiseBiomeAtPosition(Minecraft.getInstance().player.blockPosition()).value().getBackgroundMusic().orElse(Musics.GAME));
-		}
-	}
-
-	/**
-	 * Stop the game from rendering the mount health for unfriendly creatures
-	 */
-	private void removeHostileMountHealth(RenderGuiLayerEvent.Pre event) {
-		if (VanillaGuiLayers.VEHICLE_HEALTH == event.getName()) {
-			if (HostileMountEvents.isRidingUnfriendly(Minecraft.getInstance().player)) {
-				event.setCanceled(true);
-			}
-		}
-	}
-
-	/**
-	 * Render aurora effect as needed
-	 */
-	private void renderAurora(RenderLevelStageEvent event) {
-		if (Minecraft.getInstance().level == null) return;
-
-		if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_WEATHER && (aurora > 0 || lastAurora > 0) && TFShaders.AURORA != null) {
-			Tesselator tesselator = Tesselator.getInstance();
-			BufferBuilder buffer = tesselator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-
-			final float scale = 2048F * (Minecraft.getInstance().gameRenderer.getRenderDistance() / 32F);
-			Vec3 pos = event.getCamera().getPosition();
-			float y = (float) (256F - pos.y());
-			buffer.addVertex(-scale, y, scale).setColor(1F, 1F, 1F, 1F);
-			buffer.addVertex(-scale, y, -scale).setColor(1F, 1F, 1F, 1F);
-			buffer.addVertex(scale, y, -scale).setColor(1F, 1F, 1F, 1F);
-			buffer.addVertex(scale, y, scale).setColor(1F, 1F, 1F, 1F);
-
-			RenderSystem.enableBlend();
-			RenderSystem.enableDepthTest();
-			RenderSystem.setShaderColor(1F, 1F, 1F, (Mth.lerp(event.getPartialTick().getGameTimeDeltaTicks(), lastAurora, aurora)) / 60F * 0.5F);
-			TFShaders.AURORA.invokeThenEndTesselator(
-				Minecraft.getInstance().level == null ? 0 : Mth.abs((int) Minecraft.getInstance().level.getBiomeManager().biomeZoomSeed),
-				(float) pos.x(), (float) pos.y(), (float) pos.z(), buffer);
-			RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
-			RenderSystem.disableDepthTest();
-			RenderSystem.disableBlend();
-		}
-	}
-
-	private void killVignette(RenderFrameEvent.Pre event) {
-		Minecraft minecraft = Minecraft.getInstance();
-		// only fire if we're in the twilight forest
-		if (minecraft.level != null && TFDimension.DIMENSION_KEY.equals(minecraft.level.dimension())) {
-			minecraft.gui.vignetteBrightness = 0.0F;
-		}
-
-		if (minecraft.player != null && HostileMountEvents.isRidingUnfriendly(minecraft.player)) {
-			minecraft.gui.setOverlayMessage(Component.empty(), false);
-		}
-	}
-
-	private void clientTick(ClientTickEvent.Post event) {
-		Minecraft mc = Minecraft.getInstance();
-
+	private static void clientTick(Minecraft mc) {
 		if (!mc.isPaused()) {
 			time++;
 
 			lastAurora = aurora;
-			if (mc.level != null && mc.cameraEntity != null && !TFConfig.getValidAuroraBiomes(mc.level.registryAccess()).isEmpty()) {
-				RegistryAccess access = mc.level.registryAccess();
-				Holder<Biome> biome = mc.level.getBiome(mc.cameraEntity.blockPosition());
+			if (mc.level != null && mc.getCameraEntity() != null && !TFConfig.getValidAuroraBiomes(mc.level.registryAccess()).isEmpty()) {
+				var access = mc.level.registryAccess();
+				var biome = mc.level.getBiome(mc.getCameraEntity().blockPosition());
 				if (TFConfig.getValidAuroraBiomes(access).stream().anyMatch(c -> holderMatcher.match(c, biome)))
 					aurora++;
 				else
@@ -229,9 +154,8 @@ public class ClientGameEvents {
 								Player player = mc.player;
 								shakeIntensity = (float) (1.0F - mc.player.distanceToSqr(Vec3.atCenterOf(beanstalk.getBlockPos())) / Math.pow(16, 2));
 								if (shakeIntensity > 0) {
-									player.moveTo(player.getX(), player.getY(), player.getZ(),
-										player.getYRot() + (player.getRandom().nextFloat() - 0.5F) * shakeIntensity,
-										player.getXRot() + (player.getRandom().nextFloat() * 2.5F - 1.25F) * shakeIntensity);
+									player.setYRot(player.getYRot() + (player.getRandom().nextFloat() - 0.5F) * shakeIntensity);
+									player.setXRot(player.getXRot() + (player.getRandom().nextFloat() * 2.5F - 1.25F) * shakeIntensity);
 									shakeIntensity = 0.0F;
 									break;
 								}
@@ -243,101 +167,47 @@ public class ClientGameEvents {
 		}
 	}
 
-	private void shakeCamera(ViewportEvent.ComputeCameraAngles event) {
-		if (TFConfig.firstPersonEffects && !Minecraft.getInstance().isPaused() && shakeIntensity > 0 && Minecraft.getInstance().player != null) {
-			event.setYaw((float) Mth.lerp(event.getPartialTick(), event.getYaw(), event.getYaw() + (Minecraft.getInstance().player.getRandom().nextFloat() * 2F - 1F) * shakeIntensity));
-			event.setPitch((float) Mth.lerp(event.getPartialTick(), event.getPitch(), event.getPitch() + (Minecraft.getInstance().player.getRandom().nextFloat() * 2F - 1F) * shakeIntensity));
-			event.setRoll((float) Mth.lerp(event.getPartialTick(), event.getRoll(), event.getRoll() + (Minecraft.getInstance().player.getRandom().nextFloat() * 2F - 1F) * shakeIntensity));
-			shakeIntensity = 0F;
-		}
-	}
-
-	private void addCustomTooltips(ItemTooltipEvent event) {
-		ItemStack item = event.getItemStack();
-
+	private static void addCustomTooltips(ItemStack item, List<Component> lines) {
 		if (item.has(TFDataComponents.EMPERORS_CLOTH)) {
-			event.getToolTip().add(1, EMPERORS_CLOTH_TOOLTIP);
+			lines.add(1, EMPERORS_CLOTH_TOOLTIP);
 		}
 
 		if (item.is(TFItemTags.WIP)) {
-			event.getToolTip().add(WIP_TEXT);
+			lines.add(WIP_TEXT);
 		}
 	}
 
-	/**
-	 * Zooms in the FOV while using a bow, just like vanilla does in the AbstractClientPlayer's getFieldOfViewModifier() method (1.18.2)
-	 */
-	private void updateBowFOV(ComputeFovModifierEvent event) {
-		Player player = event.getPlayer();
-		if (player.isUsingItem()) {
-			Item useItem = player.getUseItem().getItem();
-			if (useItem instanceof TripleBowItem || useItem instanceof EnderBowItem || useItem instanceof IceBowItem || useItem instanceof SeekerBowItem) {
-				float f = player.getTicksUsingItem() / 20.0F;
-				f = f > 1.0F ? 1.0F : f * f;
-				event.setNewFovModifier((float) Mth.lerp(Minecraft.getInstance().options.fovEffectScale().get(), 1.0F, (event.getFovModifier() * (1.0F - f * 0.15F))));
-			}
-		}
-	}
-
-	private void unrenderHeadWithTrophies(RenderLivingEvent.Pre<?, ?> event) {
-		ItemStack stack = event.getEntity().getItemBySlot(EquipmentSlot.HEAD);
-		boolean visible = !(stack.getItem() instanceof TrophyItem) && !areCuriosEquipped(event.getEntity());
-		boolean isPlayer = event.getEntity() instanceof Player;
-		if (event.getRenderer().getModel() instanceof HeadedModel headedModel) {
-			headedModel.getHead().visible = visible && (!isPlayer || headedModel.getHead().visible);  // some mods like Better Combat can move player's head and hide it in the first person view
-			if (event.getRenderer().getModel() instanceof HumanoidModel<?> humanoidModel) {
-				humanoidModel.hat.visible = visible && (!isPlayer || humanoidModel.hat.visible);
-			}
-		}
-	}
-
-	private boolean areCuriosEquipped(LivingEntity entity) {
-		if (ModList.get().isLoaded("curios")) {
-			return CuriosCompat.isCurioEquippedAndVisible(entity, stack -> stack.getItem() instanceof TrophyItem);
-		}
-		return false;
-	}
-
-	private void translateBookAuthor(ItemTooltipEvent event) {
-		ItemStack stack = event.getItemStack();
+	private static void translateBookAuthor(ItemStack stack, List<Component> lines) {
 		if (stack.getItem() instanceof WrittenBookItem && stack.has(DataComponents.WRITTEN_BOOK_CONTENT)) {
 			if (stack.has(TFDataComponents.TRANSLATABLE_BOOK)) {
-				List<Component> components = event.getToolTip();
-				for (int i = 0; i < components.size(); i++) {
-					Component component = components.get(i);
+				for (int i = 0; i < lines.size(); i++) {
+					Component component = lines.get(i);
 					if (component.toString().contains("book.byAuthor")) {
-						components.set(i, (Component.translatable("book.byAuthor", Component.translatable(TFMain.ID + ".book.author"))).withStyle(component.getStyle()));
+						lines.set(i, (Component.translatable("book.byAuthor", Component.translatable(TFMain.ID + ".book.author"))).withStyle(component.getStyle()));
 					}
 				}
 			}
 		}
 	}
 
-	private void renderGiantBlockOutlines(RenderHighlightEvent.Block event) {
-		BlockPos pos = event.getTarget().getBlockPos();
-		BlockState state = event.getCamera().getEntity().level().getBlockState(pos);
+	private static boolean renderGiantBlockOutlines(LevelRenderContext context, BlockOutlineRenderState outline) {
+		BlockPos pos = outline.pos();
+		BlockState state = context.gameRenderer().getMainCamera().entity().level().getBlockState(pos);
 
 		if (state.getBlock() instanceof MiniatureStructureBlock) {
-			event.setCanceled(true);
-			return;
+			return false;
 		}
 
-		LocalPlayer player = Minecraft.getInstance().player;
+		Player player = Minecraft.getInstance().player;
 		if (player != null && (player.getMainHandItem().getItem() instanceof GiantPickItem || (player.getMainHandItem().getItem() instanceof BlockItem blockItem && blockItem.getBlock() instanceof GiantBlock))) {
-			event.setCanceled(true);
 			if (!state.isAir() && player.level().getWorldBorder().isWithinBounds(pos)) {
 				BlockPos offsetPos = new BlockPos(pos.getX() & ~0b11, pos.getY() & ~0b11, pos.getZ() & ~0b11);
-				VertexConsumer consumer = event.getMultiBufferSource().getBuffer(RenderType.lines());
-				Vec3 xyz = Vec3.atLowerCornerOf(offsetPos).subtract(event.getCamera().getPosition());
-				LevelRenderer.renderShape(event.getPoseStack(), consumer, GIANT_BLOCK, xyz.x(), xyz.y(), xyz.z(), 0.0F, 0.0F, 0.0F, 0.45F);
+				VertexConsumer consumer = context.bufferSource().getBuffer(RenderTypes.lines());
+				Vec3 xyz = Vec3.atLowerCornerOf(offsetPos).subtract(context.gameRenderer().getMainCamera().position());
+				ShapeRenderer.renderShape(context.poseStack(), consumer, GIANT_BLOCK, xyz.x(), xyz.y(), xyz.z(), ARGB.color(0, 0, 0), 0.45F);
 			}
+			return false;
 		}
-	}
-
-	private void renderCustomBossbars(CustomizeGuiOverlayEvent.BossEventProgress event) {
-		if (event.getBossEvent() instanceof ClientTFBossBar bossEvent) {
-			event.setCanceled(true);
-			bossEvent.renderBossBar(event.getGuiGraphics(), event.getX(), event.getY());
-		}
+		return true;
 	}
 }

--- a/src/main/resources/twilightforest.classtweaker
+++ b/src/main/resources/twilightforest.classtweaker
@@ -282,6 +282,9 @@ accessible method net/minecraft/client/gui/Gui extractFood (Lnet/minecraft/clien
 # EntityHooks
 accessible field net/minecraft/world/entity/Entity stuckSpeedMultiplier Lnet/minecraft/world/phys/Vec3;
 
+# ClientGameEvents (birthday splash override)
+accessible field net/minecraft/client/gui/screens/TitleScreen splash Lnet/minecraft/client/gui/components/SplashRenderer;
+
 # Enum Extensions
 extend-enum net/minecraft/world/damagesource/DamageEffects TWILIGHTFOREST_PINCH
 extend-enum net/minecraft/world/item/Rarity TWILIGHTFOREST_TWILIGHT

--- a/src/main/resources/twilightforest.mixins.json
+++ b/src/main/resources/twilightforest.mixins.json
@@ -4,6 +4,10 @@
   "package": "twilightforest.asm.mixin",
   "compatibilityLevel": "JAVA_25",
   "mixins": [
+    "AbstractClientPlayerFovMixin",
+    "BossHealthOverlayMixin",
+    "CameraShakeMixin",
+    "GuiVignetteMixin",
     "ServerPlayerGameModeMixin",
     "LivingEntityGetDeathSoundAccessor",
     "enums.DamageEffectsMixin",


### PR DESCRIPTION
Ports the two remaining client event hubs to 26.1/Fabric APIs. Behaviour is
recreated rather than removed.

## ClientGameEvents
- birthday splash and screen-close cache clearing via `ScreenEvents`
- client tick (`ClientTickEvents`), tooltips (`ItemTooltipCallback`)
- giant-block outlines via `LevelRenderEvents#BEFORE_BLOCK_OUTLINE`
  (26.1 `ShapeRenderer.renderShape` + `ARGB`)
- hostile-mount health hidden via `HudElementRegistry#replaceElement`
  (`VanillaHudElements.MOUNT_HEALTH`)
- beanstalk earthquake shake (`CameraShakeMixin`), bow FOV zoom
  (`AbstractClientPlayerFovMixin`), custom boss bar colours
  (`BossHealthOverlayMixin`), no vignette in the twilight dimension
  (`GuiVignetteMixin`)
- twilight-dimension music needs no mixin: 26.1 resolves `BACKGROUND_MUSIC`
  environment attributes position-aware (handled in the dimension-data batch)

## TravellersClientEvents
- movement modifiers (Agile Ranger / Straight Ahead / gradual glide /
  sidestep) applied to the 26.1 `ClientInput` move vector right after the
  input tick (`LocalPlayerInputMixin`)
- travellers keybinds via `KeyboardHandlerMixin` (+ `KeyMappingAccessor`)
- goggles zoom FOV and mouse sensitivity via `AbstractClientPlayerFovMixin`
  and `MouseHandlerMixin`
- stealth and gradual-glide state on the client tick
- packets sent through `ClientPlayNetworking`; data attachments via
  `AttachmentTarget` (`getAttached`/`setAttached`)

Also wires up all previously-orphaned client `init()` calls (CloudEvents,
LockedBiomeToastHandler, TFSkyRenderer, MapDataManager) in
`TFClient#onInitializeClient`.

First-person glove rendering still needs the 26.1 armour-model API and lands
with the TravellersArmorItem batch.