### PR TITLE
Port TravellersClientEvents to Fabric events

### DIFF
--- a/src/main/java/twilightforest/TFClient.java
+++ b/src/main/java/twilightforest/TFClient.java
@@ -2,6 +2,7 @@ package twilightforest;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import twilightforest.client.event.TravellersClientEvents;
 import twilightforest.network.*;
 
 public final class TFClient implements ClientModInitializer {
@@ -9,6 +10,7 @@ public final class TFClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		registerPackets();
+		TravellersClientEvents.init();
 	}
 
 	private static void registerPackets() {

--- a/src/main/java/twilightforest/asm/mixin/ClientInputAccessor.java
+++ b/src/main/java/twilightforest/asm/mixin/ClientInputAccessor.java
@@ -1,0 +1,13 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.player.ClientInput;
+import net.minecraft.world.phys.Vec2;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientInput.class)
+public interface ClientInputAccessor {
+
+	@Accessor("moveVector")
+	void twilightforest$setMoveVector(Vec2 moveVector);
+}

--- a/src/main/java/twilightforest/asm/mixin/KeyMappingAccessor.java
+++ b/src/main/java/twilightforest/asm/mixin/KeyMappingAccessor.java
@@ -1,0 +1,13 @@
+package twilightforest.asm.mixin;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(KeyMapping.class)
+public interface KeyMappingAccessor {
+
+	@Accessor("key")
+	InputConstants.Key twilightforest$getKey();
+}

--- a/src/main/java/twilightforest/asm/mixin/KeyboardHandlerMixin.java
+++ b/src/main/java/twilightforest/asm/mixin/KeyboardHandlerMixin.java
@@ -1,0 +1,22 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.KeyboardHandler;
+import net.minecraft.client.input.KeyEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import twilightforest.client.event.TravellersClientEvents;
+
+/**
+ * Recreates NeoForge's InputEvent.Key for the travellers' gear keybinds,
+ * after the vanilla key mappings have consumed the press.
+ */
+@Mixin(KeyboardHandler.class)
+public class KeyboardHandlerMixin {
+
+	@Inject(method = "keyPress(JILnet/minecraft/client/input/KeyEvent;)V", at = @At("TAIL"))
+	private void twilightforest$travellersKeyEvents(long window, int action, KeyEvent event, CallbackInfo ci) {
+		TravellersClientEvents.handleKeyEvent(action, event.key(), event.scancode());
+	}
+}

--- a/src/main/java/twilightforest/asm/mixin/LocalPlayerInputMixin.java
+++ b/src/main/java/twilightforest/asm/mixin/LocalPlayerInputMixin.java
@@ -1,0 +1,26 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.player.ClientInput;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.phys.Vec2;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import twilightforest.client.event.TravellersClientEvents;
+
+/**
+ * Recreates NeoForge's MovementInputUpdateEvent for the travellers' gear
+ * movement modifiers, applied right after the client input is ticked.
+ */
+@Mixin(LocalPlayer.class)
+public class LocalPlayerInputMixin {
+
+	@Inject(method = "aiStep()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/ClientInput;tick()V", shift = At.Shift.AFTER))
+	private void twilightforest$applyTravellersInput(CallbackInfo ci) {
+		LocalPlayer player = (LocalPlayer) (Object) this;
+		ClientInput input = player.input;
+		Vec2 modified = TravellersClientEvents.applyTravellersInput(input.getMoveVector());
+		((ClientInputAccessor) input).twilightforest$setMoveVector(modified);
+	}
+}

--- a/src/main/java/twilightforest/asm/mixin/MouseHandlerMixin.java
+++ b/src/main/java/twilightforest/asm/mixin/MouseHandlerMixin.java
@@ -1,0 +1,25 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.MouseHandler;
+import net.minecraft.client.OptionInstance;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import twilightforest.client.event.TravellersClientEvents;
+
+/**
+ * Recreates NeoForge's CalculatePlayerTurnEvent: while the goggles zoom is
+ * active the mouse sensitivity is scaled down.
+ */
+@Mixin(MouseHandler.class)
+public class MouseHandlerMixin {
+
+	@Redirect(method = "turnPlayer(D)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/OptionInstance;get()Ljava/lang/Object;"))
+	private Object twilightforest$zoomSensitivity(OptionInstance<?> instance) {
+		Object value = instance.get();
+		if (value instanceof Double sensitivity) {
+			return TravellersClientEvents.slowZoomSensitivity(sensitivity);
+		}
+		return value;
+	}
+}

--- a/src/main/java/twilightforest/asm/mixin/TravellersZoomFovMixin.java
+++ b/src/main/java/twilightforest/asm/mixin/TravellersZoomFovMixin.java
@@ -1,0 +1,21 @@
+package twilightforest.asm.mixin;
+
+import net.minecraft.client.player.AbstractClientPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import twilightforest.client.event.TravellersClientEvents;
+
+/**
+ * Applies the travellers' goggles zoom to the FOV modifier (formerly
+ * ComputeFovModifierEvent).
+ */
+@Mixin(AbstractClientPlayer.class)
+public class TravellersZoomFovMixin {
+
+	@Inject(method = "getFieldOfViewModifier(ZF)F", at = @At("RETURN"), cancellable = true)
+	private void twilightforest$gogglesZoom(boolean usingFOV, float partialTick, CallbackInfoReturnable<Float> cir) {
+		cir.setReturnValue(TravellersClientEvents.updateZoomState(cir.getReturnValue()));
+	}
+}

--- a/src/main/java/twilightforest/client/event/TravellersClientEvents.java
+++ b/src/main/java/twilightforest/client/event/TravellersClientEvents.java
@@ -1,25 +1,17 @@
 package twilightforest.client.event;
 
 import com.mojang.blaze3d.platform.InputConstants;
+import net.fabricmc.fabric.api.attachment.v1.AttachmentTarget;
+import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.model.HumanoidModel;
-import net.minecraft.client.model.geom.ModelPart;
-import net.minecraft.client.player.AbstractClientPlayer;
-import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
-import net.minecraft.client.renderer.entity.player.AvatarRenderer;
-import net.minecraft.client.renderer.entity.state.AvatarRenderState;
-import net.minecraft.client.renderer.rendertype.RenderTypes;
-import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.client.resources.model.EquipmentClientInfo;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -27,173 +19,148 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ProjectileWeaponItem;
 import net.minecraft.world.item.component.ItemContainerContents;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.neoforge.attachment.AttachmentType;
-import net.neoforged.neoforge.client.event.*;
-import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
-import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.registries.DeferredHolder;
-import tamaized.beanification.Component;
-import tamaized.beanification.PostConstruct;
-import twilightforest.TFMain;
+import net.minecraft.world.phys.Vec2;
+import twilightforest.asm.mixin.KeyMappingAccessor;
 import twilightforest.config.TFConfig;
-import twilightforest.tags.TFItemTags;
-import twilightforest.init.*;
+import twilightforest.init.TFAttributeModifiers;
+import twilightforest.init.TFDataAttachments;
+import twilightforest.init.TFDataComponents;
+import twilightforest.init.TFKeyBinds;
+import twilightforest.init.TFSounds;
 import twilightforest.init.custom.TravellersModifiersManager;
 import twilightforest.item.travellers_gear.TravellersArmorBeltItem;
 import twilightforest.item.travellers_gear.TravellersGearLogic;
 import twilightforest.item.travellers_gear.modifiers.TravellersModifier;
-import twilightforest.network.*;
+import twilightforest.network.CycleMapSlotPacket;
+import twilightforest.network.GogglesZoomPacket;
+import twilightforest.network.GradualGlidePacket;
+import twilightforest.network.PerformDoubleJumpPacket;
+import twilightforest.network.PerformSidestepPacket;
+import twilightforest.network.SwapHotbarPacket;
+import twilightforest.tags.TFItemTags;
 
-@Component(dist = Dist.CLIENT)
 public class TravellersClientEvents {
 
-	private static boolean isZoomKeyHeld(Player player) {
-		return TFKeyBinds.ZOOM_KEY.isDown() && !player.isScoping();
+	public static void init() {
+		ClientTickEvents.END_CLIENT_TICK.register(TravellersClientEvents::clientTick);
 	}
 
-	@PostConstruct
-	private void setup() {
-		NeoForge.EVENT_BUS.addListener(this::handleDoubleJump);
-		NeoForge.EVENT_BUS.addListener(this::handleAgileRanger);
-		NeoForge.EVENT_BUS.addListener(this::handleStraightAhead);
-		NeoForge.EVENT_BUS.addListener(this::speedUpControlledWhileSneaking);
-		NeoForge.EVENT_BUS.addListener(this::handleSidestep);
-		NeoForge.EVENT_BUS.addListener(this::handleStealth);
-		NeoForge.EVENT_BUS.addListener(this::updateZoomState);
-		NeoForge.EVENT_BUS.addListener(this::updateGradualGlideState);
-		NeoForge.EVENT_BUS.addListener(this::cycleItemDisplayMap);
-		NeoForge.EVENT_BUS.addListener(this::slowZoomSensitivity);
-		NeoForge.EVENT_BUS.addListener(this::swapHotbar);
-		NeoForge.EVENT_BUS.addListener(this::toggleRedThreadVision);
-		NeoForge.EVENT_BUS.addListener(this::renderGlovesInFirstPerson);
+	private static void clientTick(Minecraft mc) {
+		handleStealth();
+		updateGradualGlideState();
 	}
 
-	private void handleAgileRanger(MovementInputUpdateEvent event) {
-		if (!(event.getEntity() instanceof LocalPlayer localPlayer))
-			return;
+	/**
+	 * Movement input handlers (formerly MovementInputUpdateEvent) are applied by
+	 * LocalPlayerInputMixin to the ClientInput move vector.
+	 */
+	public static Vec2 applyTravellersInput(Vec2 moveVector) {
+		Minecraft minecraft = Minecraft.getInstance();
+		if (!(minecraft.player instanceof LocalPlayer localPlayer))
+			return moveVector;
+
+		float forward = moveVector.y;
+		float left = moveVector.x;
+
+		// handleAgileRanger
 		ItemStack leggingsStack = localPlayer.getItemBySlot(EquipmentSlot.LEGS);
 		Float agileRangerModifier = leggingsStack.get(TFDataComponents.AGILE_RANGER_MODIFIER);
-		if (!TravellersModifiersManager.isModifierActive(localPlayer, leggingsStack, TravellersModifiersManager.AGILE_RANGER_MODIFIER) || agileRangerModifier == null)
-			return;
-		ItemStack stack = localPlayer.getUseItem();
-		boolean isLegalItem = (stack.getItem() instanceof ProjectileWeaponItem || stack.is(TFItemTags.TRAVELLERS_AGILE_RANGER_WHITELISTED)) && !stack.is(TFItemTags.TRAVELLERS_AGILE_RANGER_BLACKLISTED);
-		if (localPlayer.isUsingItem() && !localPlayer.isPassenger() && isLegalItem) {
-			Input input = event.getInput();
-			input.leftImpulse *= agileRangerModifier;
-			input.forwardImpulse *= agileRangerModifier;
+		if (TravellersModifiersManager.isModifierActive(localPlayer, leggingsStack, TravellersModifiersManager.AGILE_RANGER_MODIFIER) && agileRangerModifier != null) {
+			ItemStack useStack = localPlayer.getUseItem();
+			boolean isLegalItem = (useStack.getItem() instanceof ProjectileWeaponItem || useStack.is(TFItemTags.TRAVELLERS_AGILE_RANGER_WHITELISTED)) && !useStack.is(TFItemTags.TRAVELLERS_AGILE_RANGER_BLACKLISTED);
+			if (localPlayer.isUsingItem() && !localPlayer.isPassenger() && isLegalItem) {
+				left *= agileRangerModifier;
+				forward *= agileRangerModifier;
+			}
 		}
-	}
 
-	private void handleStraightAhead(MovementInputUpdateEvent event) {
-		if (!(event.getEntity() instanceof LocalPlayer localPlayer))
-			return;
+		// handleStraightAhead
 		ItemStack bootsStack = localPlayer.getItemBySlot(EquipmentSlot.FEET);
 		Double multiplier = bootsStack.get(TFDataComponents.STRAIGHT_AHEAD_MULTIPLIER);
 		AttributeInstance attributeInstance = localPlayer.getAttributes().getInstance(Attributes.MOVEMENT_SPEED);
-		if (attributeInstance == null)
-			return;
+		if (attributeInstance != null) {
+			if (!TravellersModifiersManager.isModifierActive(localPlayer, bootsStack, TravellersModifiersManager.STRAIGHT_AHEAD_MODIFIER) || multiplier == null || forward <= 0)
+				multiplier = 1D;
+			attributeInstance.addOrUpdateTransientModifier(new AttributeModifier(TFAttributeModifiers.STRAIGHT_AHEAD_ATTRIBUTE_MODIFIER_LOCATION, multiplier - 1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL));
+			left /= multiplier;
+		}
 
-		Input input = localPlayer.input;
-		if (!TravellersModifiersManager.isModifierActive(localPlayer, bootsStack, TravellersModifiersManager.STRAIGHT_AHEAD_MODIFIER) || multiplier == null || input.forwardImpulse <= 0)
-			multiplier = 1D;
-		attributeInstance.addOrUpdateTransientModifier(new AttributeModifier(TFAttributeModifiers.STRAIGHT_AHEAD_ATTRIBUTE_MODIFIER_LOCATION, multiplier - 1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL));
-		input.leftImpulse /= multiplier;
-	}
+		// speedUpControlledWhileSneaking
+		AttachmentTarget target = localPlayer;
+		if (target.getAttached(TFDataAttachments.IS_GRADUALLY_GLIDING) && localPlayer.isShiftKeyDown()) {
+			forward /= 0.2F;
+			left /= 0.2F;
+		}
 
-	private void speedUpControlledWhileSneaking(MovementInputUpdateEvent event) {
-		if (!(event.getEntity() instanceof LocalPlayer localPlayer) || !localPlayer.getData(TFDataAttachments.IS_GRADUALLY_GLIDING) || !localPlayer.isShiftKeyDown())
-			return;
-		localPlayer.input.forwardImpulse /= 0.2F;
-		localPlayer.input.leftImpulse /= 0.2F;
-	}
+		// handleSidestep
+		if (localPlayer.onGround()) {
+			boolean lastImpulseZero = target.getAttached(TFDataAttachments.LAST_HORIZONTAL_IMPULSE) == 0;
+			boolean sameImpulseDirection = Math.signum(target.getAttached(TFDataAttachments.LAST_NON_ZERO_HORIZONTAL_IMPULSE)) == Math.signum(left);
+			int currentTime = localPlayer.tickCount;
+			int lastWalkingTime = target.getAttached(TFDataAttachments.LAST_HORIZONTAL_WALKING_TIME);
+			boolean hasDoubleTapped = currentTime - lastWalkingTime < 4;
 
-	private void handleSidestep(MovementInputUpdateEvent event) {
-		if (!(event.getEntity() instanceof LocalPlayer localPlayer) || !localPlayer.onGround())
-			return;
+			if (lastImpulseZero && sameImpulseDirection && hasDoubleTapped && left != 0) {
+				boolean isLeftSidestep = left > 0;
+				if (TravellersGearLogic.tryPerformSidestep(localPlayer, isLeftSidestep)) {
+					ClientPlayNetworking.send(new PerformSidestepPacket(isLeftSidestep));
+				}
+			}
 
-		Input input = localPlayer.input;
-		boolean lastImpulseZero = localPlayer.getData(TFDataAttachments.LAST_HORIZONTAL_IMPULSE) == 0;
-		boolean sameImpulseDirection = Math.signum(localPlayer.getData(TFDataAttachments.LAST_NON_ZERO_HORIZONTAL_IMPULSE)) == Math.signum(input.leftImpulse);
-		int currentTime = localPlayer.tickCount;
-		int lastWalkingTime = localPlayer.getData(TFDataAttachments.LAST_HORIZONTAL_WALKING_TIME);
-		boolean hasDoubleTapped = currentTime - lastWalkingTime < 4;
-
-		if (lastImpulseZero && sameImpulseDirection && hasDoubleTapped && input.leftImpulse != 0) {
-			boolean isLeftSidestep = input.leftImpulse > 0;
-			if (TravellersGearLogic.tryPerformSidestep(localPlayer, isLeftSidestep)) {
-				localPlayer.connection.send(new PerformSidestepPacket(isLeftSidestep));
+			target.setAttached(TFDataAttachments.LAST_HORIZONTAL_IMPULSE, left);
+			if (left != 0) {
+				target.setAttached(TFDataAttachments.LAST_HORIZONTAL_WALKING_TIME, currentTime);
+				target.setAttached(TFDataAttachments.LAST_NON_ZERO_HORIZONTAL_IMPULSE, left);
 			}
 		}
 
-		localPlayer.setData(TFDataAttachments.LAST_HORIZONTAL_IMPULSE, input.leftImpulse);
-		if (input.leftImpulse != 0) {
-			localPlayer.setData(TFDataAttachments.LAST_HORIZONTAL_WALKING_TIME, currentTime);
-			localPlayer.setData(TFDataAttachments.LAST_NON_ZERO_HORIZONTAL_IMPULSE, input.leftImpulse);
-		}
+		return new Vec2(left, forward);
 	}
 
-	private void handleStealth(RenderFrameEvent.Pre event) {
-		if (Minecraft.getInstance().level == null)
+	/**
+	 * Key handlers (formerly InputEvent.Key) are invoked by KeyboardHandlerMixin
+	 * after the vanilla key mappings have consumed the press.
+	 */
+	public static void handleKeyEvent(int action, int keyCode, int scanCode) {
+		if (Minecraft.getInstance().screen != null)
 			return;
-		for (Entity entity : Minecraft.getInstance().level.entitiesForRendering()) {
-			if (!(entity instanceof Player player)) continue;
-			TravellersGearLogic.travellersStealth(player, player1 -> player1.setInvisible(true));  // call it on client to make player invisible instantly
-		}
-	}
 
-	private void handleDoubleJump(InputEvent.Key event) {
-		if (!(Minecraft.getInstance().player instanceof LocalPlayer localPlayer) || ignoreKeyEvent(event, Minecraft.getInstance().options.keyJump))
-			return;
-		int lastJumpKeyPressTime = localPlayer.getData(TFDataAttachments.LAST_JUMP_KEY_PRESS_TIME);
-		boolean pressedKey = event.getAction() == InputConstants.PRESS;
-		if (pressedKey)
-			localPlayer.setData(TFDataAttachments.LAST_JUMP_KEY_PRESS_TIME, localPlayer.tickCount);
-		boolean avoidCreativeFly = localPlayer.mayFly() && localPlayer.tickCount - lastJumpKeyPressTime <= 6;
-		if (pressedKey && !avoidCreativeFly && TravellersModifiersManager.isModifierActive(localPlayer, TravellersModifiersManager.DOUBLE_JUMP_MODIFIER)) {
-			if (TravellersGearLogic.performDoubleJump(localPlayer)) {
-				localPlayer.connection.send(new PerformDoubleJumpPacket());
+		// handleDoubleJump
+		if (Minecraft.getInstance().player instanceof LocalPlayer localPlayer && !ignoreKeyEvent(keyCode, scanCode, action, Minecraft.getInstance().options.keyJump)) {
+			AttachmentTarget target = localPlayer;
+			int lastJumpKeyPressTime = target.getAttached(TFDataAttachments.LAST_JUMP_KEY_PRESS_TIME);
+			boolean pressedKey = action == InputConstants.PRESS;
+			if (pressedKey)
+				target.setAttached(TFDataAttachments.LAST_JUMP_KEY_PRESS_TIME, localPlayer.tickCount);
+			boolean avoidCreativeFly = localPlayer.getAbilities().mayfly && localPlayer.tickCount - lastJumpKeyPressTime <= 6;
+			if (pressedKey && !avoidCreativeFly && TravellersModifiersManager.isModifierActive(localPlayer, TravellersModifiersManager.DOUBLE_JUMP_MODIFIER)) {
+				if (TravellersGearLogic.performDoubleJump(localPlayer)) {
+					ClientPlayNetworking.send(new PerformDoubleJumpPacket());
+				}
 			}
 		}
+
+		cycleItemDisplayMap();
+		swapHotbar();
+		toggleRedThreadVision();
 	}
 
-	private void updateZoomState(ComputeFovModifierEvent event) {
-		LocalPlayer player = Minecraft.getInstance().player;
-		if (player == null) return;
-		boolean wasUsingZoom = player.getData(TFDataAttachments.IS_USING_GOGGLES_ZOOM_MODIFIER);
-		ItemStack headStack = player.getItemBySlot(EquipmentSlot.HEAD);
-		Float zoomModifier = headStack.get(TFDataComponents.ZOOM_ABILITY_MODIFIER);
-		boolean isUsingZoom = isZoomKeyHeld(player) && TravellersModifiersManager.isModifierActive(player, headStack, TravellersModifiersManager.ZOOM_ABILITY) && zoomModifier != null;
-		if (isUsingZoom)
-			event.setNewFovModifier(event.getNewFovModifier() * zoomModifier);
-		if (isUsingZoom == wasUsingZoom)
-			return;
-
-		player.setData(TFDataAttachments.IS_USING_GOGGLES_ZOOM_MODIFIER, isUsingZoom);
-		player.playSound(isUsingZoom ? TFSounds.GOGGLES_ZOOM_IN.get() : TFSounds.GOGGLES_ZOOM_OUT.get());
-		player.connection.send(new GogglesZoomPacket(isUsingZoom, player.getUUID()));
+	private static boolean ignoreKeyEvent(int keyCode, int scanCode, int action, KeyMapping key) {
+		return !keyMatches(key, keyCode, scanCode) || action != InputConstants.PRESS || Minecraft.getInstance().screen != null;
 	}
 
-	private void updateGradualGlideState(RenderFrameEvent.Pre event) {
-		LocalPlayer player = Minecraft.getInstance().player;
-		if (player == null) return;
-		boolean wasGraduallyGliding = player.getData(TFDataAttachments.IS_GRADUALLY_GLIDING);
-		boolean shiftHeld = player.isShiftKeyDown();
-		boolean isGraduallyGliding = TFConfig.manualTravellersWingsGradualGlideDefault == shiftHeld && player.getKnownMovement().y() < 0 && !player.onGround();
-		if (isGraduallyGliding == wasGraduallyGliding)
-			return;
-
-		player.setData(TFDataAttachments.IS_GRADUALLY_GLIDING, isGraduallyGliding);
-		player.connection.send(new GradualGlidePacket(isGraduallyGliding, player.getUUID()));
+	private static boolean keyMatches(KeyMapping key, int keyCode, int scanCode) {
+		var boundKey = ((KeyMappingAccessor) key).twilightforest$getKey();
+		return boundKey.getValue() == keyCode || boundKey.getValue() == scanCode;
 	}
 
-	private void cycleItemDisplayMap(InputEvent.Key event) {
+	private static void cycleItemDisplayMap() {
 		if (!(Minecraft.getInstance().player instanceof LocalPlayer localPlayer) || !TFKeyBinds.ITEM_DISPLAY_MAP_CYCLE_KEY.consumeClick())
 			return;
-		localPlayer.connection.send(CycleMapSlotPacket.INSTANCE);
+		ClientPlayNetworking.send(CycleMapSlotPacket.INSTANCE);
 	}
 
-	private void swapHotbar(InputEvent.Key event) {
+	private static void swapHotbar() {
 		if (!TFKeyBinds.SWAP_HOTBAR_KEY.consumeClick())
 			return;
 		Player player = Minecraft.getInstance().player;
@@ -202,14 +169,14 @@ public class TravellersClientEvents {
 		ItemContainerContents containerContents = legArmor.get(DataComponents.CONTAINER);
 		if (!TravellersArmorBeltItem.hasSwapHotbar(player, legArmor) || containerContents == null)
 			return;
-		localPlayer.connection.send(SwapHotbarPacket.INSTANCE);
+		ClientPlayNetworking.send(SwapHotbarPacket.INSTANCE);
 	}
 
-	private void toggleRedThreadVision(InputEvent.Key event) {
-		this.toggleBooleanDataAttachment(TFKeyBinds.RED_THREAD_VISION_KEY.consumeClick(), TravellersModifiersManager.RED_THREAD_VISION_MODIFIER, TFDataAttachments.TRAVELLERS_GOGGLES_RED_THREAD_VISION);
+	private static void toggleRedThreadVision() {
+		toggleBooleanDataAttachment(TFKeyBinds.RED_THREAD_VISION_KEY.consumeClick(), TravellersModifiersManager.RED_THREAD_VISION_MODIFIER, TFDataAttachments.TRAVELLERS_GOGGLES_RED_THREAD_VISION);
 	}
 
-	private void toggleBooleanDataAttachment(boolean pressed, ResourceKey<TravellersModifier> modifier, DeferredHolder<AttachmentType<?>, AttachmentType<Boolean>> attachment) {
+	private static void toggleBooleanDataAttachment(boolean pressed, ResourceKey<TravellersModifier> modifier, AttachmentType<Boolean> attachment) {
 		if (!pressed)
 			return;
 
@@ -217,65 +184,78 @@ public class TravellersClientEvents {
 		if (player == null || !TravellersModifiersManager.isModifierActive(player, modifier))
 			return;
 
-		boolean current = player.getData(attachment.get());
-		player.setData(attachment.get(), !current);
+		boolean current = ((AttachmentTarget) player).getAttached(attachment);
+		((AttachmentTarget) player).setAttached(attachment, !current);
 	}
 
-	private void slowZoomSensitivity(CalculatePlayerTurnEvent event) {
-		Player player = Minecraft.getInstance().player; // Player is never null but we need to check for null to avoid warnings
-		if (event.getCinematicCameraEnabled() || player == null)
-			return;
+	/**
+	 * FOV modifier for the goggles zoom (formerly ComputeFovModifierEvent), called
+	 * from AbstractClientPlayerFovMixin.
+	 */
+	public static float updateZoomState(float fovModifier) {
+		Player player = Minecraft.getInstance().player;
+		if (player == null) return fovModifier;
+		boolean wasUsingZoom = ((AttachmentTarget) player).getAttached(TFDataAttachments.IS_USING_GOGGLES_ZOOM_MODIFIER);
+		ItemStack headStack = player.getItemBySlot(EquipmentSlot.HEAD);
+		Float zoomModifier = headStack.get(TFDataComponents.ZOOM_ABILITY_MODIFIER);
+		boolean isUsingZoom = isZoomKeyHeld(player) && TravellersModifiersManager.isModifierActive(player, headStack, TravellersModifiersManager.ZOOM_ABILITY) && zoomModifier != null;
+		if (isUsingZoom)
+			fovModifier = fovModifier * zoomModifier;
+		if (isUsingZoom == wasUsingZoom)
+			return fovModifier;
+
+		((AttachmentTarget) player).setAttached(TFDataAttachments.IS_USING_GOGGLES_ZOOM_MODIFIER, isUsingZoom);
+		player.playSound(isUsingZoom ? TFSounds.GOGGLES_ZOOM_IN.value() : TFSounds.GOGGLES_ZOOM_OUT.value());
+		ClientPlayNetworking.send(new GogglesZoomPacket(isUsingZoom, player.getUUID()));
+		return fovModifier;
+	}
+
+	/**
+	 * Mouse sensitivity for the goggles zoom (formerly CalculatePlayerTurnEvent),
+	 * called from MouseHandlerMixin.
+	 */
+	public static double slowZoomSensitivity(double mouseSensitivity) {
+		Player player = Minecraft.getInstance().player;
+		if (Minecraft.getInstance().options.smoothCamera || player == null)
+			return mouseSensitivity;
 
 		ItemStack headStack = player.getItemBySlot(EquipmentSlot.HEAD);
 		Float zoomModifier = headStack.get(TFDataComponents.ZOOM_ABILITY_MODIFIER);
 		if (zoomModifier == null || !isZoomKeyHeld(player))
-			return;
+			return mouseSensitivity;
 
-		double mouseSensitivity = event.getMouseSensitivity();
-		// vanilla math for turning is (m * 0.6 + 0.2)³ * 8; where m is the mouse sensitivity
-		// vanilla spyglasses avoid using the "* 8" part, so we probably want to as well
-		// the mod value to reverse that was borrowed from IE since they also have zoom functionality
-		// we can then divide by our zoom modifier (and add 0.05 to slow it down slightly) to set the sensitivity to a reasonable value when zooming
 		double mod = 0.5D - 1 / (6 * mouseSensitivity);
 		double fovMod = zoomModifier + 0.05F;
-		event.setMouseSensitivity(mod * mouseSensitivity / fovMod);
+		return mod * mouseSensitivity / fovMod;
 	}
 
-	private boolean ignoreKeyEvent(InputEvent.Key event, KeyMapping key) {
-		return !key.matches(event.getKey(), event.getScanCode()) || event.getAction() != InputConstants.PRESS || Minecraft.getInstance().screen != null;
+	private static boolean isZoomKeyHeld(Player player) {
+		return TFKeyBinds.ZOOM_KEY.isDown() && !player.isScoping();
 	}
 
-	@SuppressWarnings("unchecked") //meh
-	private void renderGlovesInFirstPerson(RenderArmEvent event) {
-        if (!TFConfig.firstPersonGloveOverlay)
+	private static void handleStealth() {
+		if (Minecraft.getInstance().level == null)
+			return;
+		for (Entity entity : Minecraft.getInstance().level.entitiesForRendering()) {
+			if (!(entity instanceof Player player)) continue;
+			TravellersGearLogic.travellersStealth(player, player1 -> player1.setInvisible(true));
+		}
+	}
+
+	private static void updateGradualGlideState() {
+		Player player = Minecraft.getInstance().player;
+		if (player == null) return;
+		boolean wasGraduallyGliding = ((AttachmentTarget) player).getAttached(TFDataAttachments.IS_GRADUALLY_GLIDING);
+		boolean shiftHeld = player.isShiftKeyDown();
+		boolean isGraduallyGliding = TFConfig.manualTravellersWingsGradualGlideDefault == shiftHeld && player.getKnownMovement().y() < 0 && !player.onGround();
+		if (isGraduallyGliding == wasGraduallyGliding)
 			return;
 
-        AbstractClientPlayer player = event.getPlayer();
-        ItemStack chestStack = player.getItemBySlot(EquipmentSlot.CHEST);
-        if (!chestStack.has(TFDataComponents.TRAVELLERS_HAS_GLOVES) || chestStack.has(TFDataComponents.EMPERORS_CLOTH))
-            return;
+		((AttachmentTarget) player).setAttached(TFDataAttachments.IS_GRADUALLY_GLIDING, isGraduallyGliding);
+		ClientPlayNetworking.send(new GradualGlidePacket(isGraduallyGliding, player.getUUID()));
+	}
 
-		Minecraft minecraft = Minecraft.getInstance();
-		EntityRenderDispatcher renderDispatcher = minecraft.getEntityRenderDispatcher();
-
-		if (!(renderDispatcher.getRenderer(player) instanceof AvatarRenderer avatarRenderer))
-            return;
-
-		if (!(IClientItemExtensions.of(TFItems.TRAVELLERS_GLOVES.get()).getHumanoidArmorModel(chestStack, EquipmentClientInfo.LayerType.HUMANOID, avatarRenderer.getModel()) instanceof HumanoidModel model))
-			return;
-
-		if (!(avatarRenderer.createRenderState(player, minecraft.getDeltaTracker().getGameTimeDeltaPartialTick(false)) instanceof AvatarRenderState renderState))
-			return;
-
-		renderState.attackTime = 0.0F;
-		renderState.isCrouching = false;
-		renderState.swimAmount = 0.0F;
-        model.setupAnim(renderState);
-
-		ModelPart armPart = event.getArm() == HumanoidArm.RIGHT ? model.rightArm : model.leftArm;
-        armPart.xRot = 0.0F;
-
-        Identifier gloveLocation = TFMain.prefix("textures/models/armor/travellers_layer_1.png");
-		event.getSubmitNodeCollector().submitModelPart(armPart, event.getPoseStack(), RenderTypes.armorCutoutNoCull(gloveLocation), event.getPackedLight(), OverlayTexture.NO_OVERLAY, null);
-    }
+	// TODO [Fabric] renderGlovesInFirstPerson needs the 26.1 armour-model API
+	// migration (IClientItemExtensions replacement) and will land with the
+	// TravellersArmorItem batch.
 }

--- a/src/main/resources/twilightforest.mixins.json
+++ b/src/main/resources/twilightforest.mixins.json
@@ -4,7 +4,13 @@
   "package": "twilightforest.asm.mixin",
   "compatibilityLevel": "JAVA_25",
   "mixins": [
+    "ClientInputAccessor",
+    "KeyMappingAccessor",
+    "KeyboardHandlerMixin",
+    "LocalPlayerInputMixin",
+    "MouseHandlerMixin",
     "ServerPlayerGameModeMixin",
+    "TravellersZoomFovMixin",
     "LivingEntityGetDeathSoundAccessor",
     "enums.DamageEffectsMixin",
     "enums.GrassColorModifierMixin",


### PR DESCRIPTION
- movement input handlers (Agile Ranger, Straight Ahead, gradual-glide speed-up, sidestep) apply to the 26.1 ClientInput move vector right after the input tick (LocalPlayerInputMixin)
- travellers keybinds handled from KeyboardHandlerMixin with a KeyMappingAccessor for the jump keybind
- goggles zoom FOV modifier (TravellersZoomFovMixin) and mouse-sensitivity scaling (MouseHandlerMixin)
- stealth and gradual-glide state checks run on the client tick
- packets sent through ClientPlayNetworking; data attachments via AttachmentTarget (getAttached/setAttached)
- first-person glove rendering still needs the 26.1 armour-model API and lands with the TravellersArmorItem batch