### PR TITLE
Port TravellersArmorItem and its armour renderers to 26.1

### DIFF
--- a/src/main/java/twilightforest/client/model/armor/TravellersWingsModel.java
+++ b/src/main/java/twilightforest/client/model/armor/TravellersWingsModel.java
@@ -18,7 +18,7 @@ import twilightforest.util.TFMathUtil;
 import java.util.Collections;
 import java.util.List;
 
-public class TravellersWingsModel extends HumanoidModel<LivingEntity> {
+public class TravellersWingsModel extends HumanoidModel<net.minecraft.client.renderer.entity.state.HumanoidRenderState> {
 	private static final double TAU = 4;  // Time (in ticks) in which distance reduces in e times
 	private static final float ANGLE_10_DEG = Mth.PI / 18;
 	private static final Vector3f SMALL_SWING = new Vector3f(8.0F, 8.0F, 8.0F);
@@ -167,67 +167,12 @@ public class TravellersWingsModel extends HumanoidModel<LivingEntity> {
 		);
 	}
 
-	public void setupModelAnimations(LivingEntity entity, float f, float f1, double ageInTicks, float netHeadYaw, float headPitch) {
-		this.bodyParts().forEach(modelPart -> modelPart.getAllParts().forEach(ModelPart::resetPose));
-		super.setupAnim(entity, f, f1, (float) ageInTicks, netHeadYaw, headPitch);
-		TravellersWingsAnimAttachment animAttachment = entity.getData(TFDataAttachments.TRAVELLERS_WINGS_ANIM);
-		TravellersWingsAttachment attachment = entity.getData(TFDataAttachments.TRAVELLERS_WINGS);
-
-		double dtInTicks = ageInTicks - animAttachment.oldAgeInTicks;
-
-		//slightly move wings down when crouching so they arent detached
-		if (entity.isCrouching()) {
-			this.wingBaseRight.y += 2;
-			this.wingBaseLeft.y += 2;
-		}
-
-		Vector3f rightWingRotations;  // must be initialized later
-		double interpolationSpeed = TAU;
-		float targetLeftWingY;
-		switch (attachment.state) {
-			case DOUBLE_JUMP -> {
-				rightWingRotations = new Vector3f(-0.4F, -0.8F, -0.1F);
-				interpolationSpeed = TAU - 1;
-			}
-			case RIDE -> rightWingRotations = this.calculateRotations(animAttachment, dtInTicks, 10.0F, ANGLE_10_DEG * 3, -0.6F, -0.3F, BIG_SWING);
-			case SWIM -> rightWingRotations = this.calculateRotations(animAttachment, dtInTicks, 17.0F, ANGLE_10_DEG * 4, -1.0F, -0.5F, BIG_SWING);
-			case FALL_SLOW -> rightWingRotations = this.calculateRotations(animAttachment, dtInTicks, 17.0F, ANGLE_10_DEG * 5, -1.1F, -0.1F, BIG_SWING);
-			case FALL_FAST -> rightWingRotations = this.calculateRotations(animAttachment, dtInTicks, 2.0F, ANGLE_10_DEG * 4, -1.1F, -0.3F, SMALL_SWING);
-			case SPRINT -> rightWingRotations = this.calculateRotations(animAttachment, dtInTicks, 2.0F, ANGLE_10_DEG * 3, -0.3F, 0.0F, BIG_SWING);
-			case SIDESTEP -> rightWingRotations = this.calculateRotations(animAttachment, dtInTicks, 2.0F, ANGLE_10_DEG * 3, attachment.sidestepLeft ? -0.6F : 0.4F, 0.0F, BIG_SWING);
-			default -> {
-				float phaseDivisor = entity.walkAnimation.speed() > 0.1 ? 4.0F : 20.0F;  // use 0.1 instead of isMoving to avoid increasing animation speed when legs barely move
-				rightWingRotations = this.calculateRotations(animAttachment, dtInTicks, phaseDivisor, ANGLE_10_DEG * 3, -0.6F, -0.3F, BIG_SWING);
-			}
-		}
-
-		this.wingBaseRight.xRot = (float) TFMathUtil.interpolateToTarget(animAttachment.xRotOld, rightWingRotations.x, dtInTicks, interpolationSpeed);
-		this.wingBaseRight.yRot = (float) TFMathUtil.interpolateToTarget(animAttachment.yRotOldRight, rightWingRotations.y, dtInTicks, interpolationSpeed);
-		this.wingBaseRight.zRot = (float) TFMathUtil.interpolateToTarget(animAttachment.zRotOld, rightWingRotations.z, dtInTicks, interpolationSpeed);
-
-		targetLeftWingY = attachment.state.equals(TravellersWingsAttachment.WingState.SIDESTEP)
-			? this.calculateRotations(animAttachment, dtInTicks, 2.0F, ANGLE_10_DEG * 3, attachment.sidestepLeft ? -0.4F : 0.6F, 0.0F, BIG_SWING).y()
-			: -rightWingRotations.y();
-		this.wingBaseLeft.xRot = this.wingBaseRight.xRot;
-		this.wingBaseLeft.yRot = (float) TFMathUtil.interpolateToTarget(animAttachment.yRotOldLeft, targetLeftWingY, dtInTicks, interpolationSpeed);
-		this.wingBaseLeft.zRot = -this.wingBaseRight.zRot;
-
-		animAttachment.accumulatedPhase = animAttachment.accumulatedPhase % Mth.TWO_PI;
-		animAttachment.oldAgeInTicks = ageInTicks;
-		animAttachment.xRotOld = this.wingBaseRight.xRot;
-		animAttachment.yRotOldRight = this.wingBaseRight.yRot;
-		animAttachment.yRotOldLeft = this.wingBaseLeft.yRot;
-		animAttachment.zRotOld = this.wingBaseRight.zRot;
-
-		// If the wing model keeps a non-changing offset then looking at it with a spyglass even 4 chunks away will reveal Z-fighting.
-		float distance = (float) (Math.sqrt(entity.distanceToSqr(this.mainCamera.getPosition())) * PART_OFFSET);
-		// The below solution is to animate its offset based off of camera distance. The animation is not time-based.
-		int partCount = Math.min(this.wingPartsLeft.size(), this.wingPartsRight.size());
-		for (int partIndex = 0; partIndex < partCount; partIndex++) {
-			float offset = (partIndex + 1) * distance;
-			this.wingPartsLeft.get(partIndex).x = BASE_OFFSET + offset;
-			this.wingPartsRight.get(partIndex).x = BASE_OFFSET - offset;
-		}
+	@Override
+	public void setupAnim(net.minecraft.client.renderer.entity.state.HumanoidRenderState state) {
+		super.setupAnim(state);
+		// TODO [Fabric] the live wings animation relies on entity data (wings
+		// attachments, walk animation). That data needs to be piped into the
+		// render state during extract before the animation can be restored.
 	}
 
 	private Vector3f calculateRotations(TravellersWingsAnimAttachment attachment, double dtInTicks, float phaseDivisor, float xOffset, float yOffset, float zOffset, Vector3f sinDivisors) {
@@ -238,16 +183,6 @@ public class TravellersWingsModel extends HumanoidModel<LivingEntity> {
 			sinT / sinDivisors.y + yOffset,
 			sinT / sinDivisors.z + zOffset
 		);
-	}
-
-	@Override
-	protected Iterable<ModelPart> headParts() {
-		return Collections.emptyList();
-	}
-
-	@Override
-	protected Iterable<ModelPart> bodyParts() {
-		return ImmutableList.of(body, leftLeg, rightLeg);
 	}
 
 	public static void skipWings(ModelPart leggingsLayer, boolean skip) {

--- a/src/main/java/twilightforest/client/renderer/armor/TFArmorRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/armor/TFArmorRenderer.java
@@ -5,37 +5,38 @@ import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
-import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
-import net.neoforged.neoforge.common.util.Lazy;
+import net.fabricmc.fabric.api.client.rendering.v1.ArmorRenderer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
-public abstract class TFArmorRenderer implements IClientItemExtensions {
+public abstract class TFArmorRenderer implements ArmorRenderer {
 	public static final List<TFSimpleArmorRenderer> INSTANCES = new ArrayList<>();
-	protected final Map<ModelLayerLocation, Lazy<ModelPart>> ARMOR_MODELS = new HashMap<>();
+	protected final Map<ModelLayerLocation, ModelPart> ARMOR_MODELS = new HashMap<>();
 
 	public TFArmorRenderer(ModelLayerLocation... layerLocations) {
 		for (ModelLayerLocation layerLocation : layerLocations) {
-			this.ARMOR_MODELS.put(
-				layerLocation,
-				Lazy.of(() -> Minecraft.getInstance().getEntityModels().bakeLayer(layerLocation))
-			);
+			ARMOR_MODELS.put(layerLocation, bakeLayer(layerLocation));
 		}
 	}
 
+	private static ModelPart bakeLayer(ModelLayerLocation layerLocation) {
+		return Minecraft.getInstance().getEntityModels().bakeLayer(layerLocation);
+	}
+
 	public void resetModelCache() {
-		ARMOR_MODELS.values().forEach(Lazy::invalidate);
+		ARMOR_MODELS.replaceAll((layer, model) -> bakeLayer(layer));
 	}
 
 	public static void resetAllModelCache() {
-		INSTANCES.forEach(TFSimpleArmorRenderer::resetModelCache);
+		INSTANCES.forEach(TFArmorRenderer::resetModelCache);
 	}
 
 	protected ModelPart getModelPart(ModelLayerLocation layerLocation) {
-		return ARMOR_MODELS.get(layerLocation).get();
+		return ARMOR_MODELS.get(layerLocation);
 	}
 
 	public static final class ResourceReloadListener implements ResourceManagerReloadListener {

--- a/src/main/java/twilightforest/client/renderer/armor/TFSimpleArmorRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/armor/TFSimpleArmorRenderer.java
@@ -1,11 +1,17 @@
 package twilightforest.client.renderer.armor;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.HumanoidModel;
-import net.minecraft.client.model.Model;
 import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.model.geom.ModelPart;
-import net.minecraft.client.resources.model.EquipmentClientInfo;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.equipment.Equippable;
 import twilightforest.client.model.armor.TFArmorModel;
 
 import java.util.function.Function;
@@ -23,9 +29,24 @@ public class TFSimpleArmorRenderer extends TFArmorRenderer {
 	}
 
 	@Override
-	public HumanoidModel<?> getHumanoidArmorModel(ItemStack itemStack, EquipmentClientInfo.LayerType layerType, Model original) {
-		return layerType == EquipmentClientInfo.LayerType.HUMANOID_LEGGINGS ?
-			CREATE_MODEL_INSTANCE.apply(getModelPart(INNER_ARMOR_MODEL)) :
-			CREATE_MODEL_INSTANCE.apply(getModelPart(OUTER_ARMOR_MODEL));
+	public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, SubmitNodeCollector collector, ItemStack stack, HumanoidRenderState state, EquipmentSlot slot, int light, HumanoidModel<HumanoidRenderState> contextModel) {
+		if (!stack.has(DataComponents.EQUIPPABLE))
+			return;
+
+		Equippable equippable = stack.get(DataComponents.EQUIPPABLE);
+		boolean leggings = equippable.slot() == EquipmentSlot.LEGS;
+		ModelPart root = getModelPart(leggings ? INNER_ARMOR_MODEL : OUTER_ARMOR_MODEL);
+		TFArmorModel armorModel = CREATE_MODEL_INSTANCE.apply(root);
+		armorModel.setupAnim(state);
+
+		Identifier texture = equippable.assetId()
+			.map(id -> fromEquipmentAsset(id.identifier(), leggings))
+			.orElseGet(() -> Identifier.withDefaultNamespace("textures/models/armor/leather_layer_" + (leggings ? 2 : 1) + ".png"));
+
+		collector.submitModel(armorModel, state, poseStack, armorModel.renderType(texture), light, OverlayTexture.NO_OVERLAY, 0xffffffff, null);
+	}
+
+	private static Identifier fromEquipmentAsset(Identifier assetId, boolean leggings) {
+		return Identifier.fromNamespaceAndPath(assetId.getNamespace(), "textures/entity/equipment/armor/" + assetId.getPath() + "_layer_" + (leggings ? 2 : 1) + ".png");
 	}
 }

--- a/src/main/java/twilightforest/item/travellers_gear/TravellersArmorItem.java
+++ b/src/main/java/twilightforest/item/travellers_gear/TravellersArmorItem.java
@@ -26,7 +26,7 @@ import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.equipment.ArmorMaterial;
 import net.minecraft.world.item.equipment.ArmorType;
-import net.neoforged.neoforge.common.util.ConcatenatedListView;
+import carminite.util.ConcatenatedListView;
 import org.jspecify.annotations.Nullable;
 import twilightforest.TFMain;
 import twilightforest.client.model.TFModelLayers;
@@ -110,7 +110,7 @@ public class TravellersArmorItem extends Item implements TravellersModifiable {
 		List<Holder.Reference<TravellersModifier>> insertableModifiers = TravellersModifiersManager.findAllInsertableModifiers(registries, stack);
 		for (Holder.Reference<TravellersModifier> modifier : insertableModifiers) {
 			builder.accept(Component.literal("- ").append(TravellersModifiersManager.getModifierTooltipComponent(modifier).withStyle(ChatFormatting.GRAY)));
-			if (flag.hasShiftDown()) {
+			if (flag.isAdvanced()) {
 				for (Component description : modifier.value().getDescription()) {
 					// FIXME There has to be a better way to bold only the indent and arrow and not the information component
 					builder.accept(Component.literal("").append(Component.translatable("travellers_gear.info_indent").withStyle(ChatFormatting.BOLD)).append(description));
@@ -122,11 +122,11 @@ public class TravellersArmorItem extends Item implements TravellersModifiable {
 			builder.accept(Component.literal("- ").append(Component.translatable("travellers_gear.modifier.empty").withStyle(ChatFormatting.DARK_GRAY)));
 		}
 
-		if (TFItems.TRAVELLERS_GLOVES.get() == this) {
+		if (TFItems.TRAVELLERS_GLOVES == this) {
 			builder.accept(GLOVES_TOOLTIP);
 		}
 
-		if (!flag.hasShiftDown()) {
+		if (!flag.isAdvanced()) {
 			ConcatenatedListView<Holder.Reference<TravellersModifier>> modifiers = ConcatenatedListView.of(abilityModifiers, insertableModifiers);
 			boolean hasHiddenDescriptions = modifiers.stream().map(Holder::value).map(TravellersModifier::getDescription).anyMatch(Predicate.not(List::isEmpty));
 			if (hasHiddenDescriptions) {
@@ -134,22 +134,6 @@ public class TravellersArmorItem extends Item implements TravellersModifiable {
 			}
 		}
 	}
-
-	@Override
-	public boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
-		return false;
-	}
-
-	@Override
-	public boolean supportsEnchantment(ItemStack stack, Holder<Enchantment> enchantment) {
-		return false;
-	}
-
-	@Override
-	public boolean canWalkOnPowderedSnow(ItemStack stack, LivingEntity wearer) {
-		return stack.is(TFItems.TRAVELLERS_BOOTS);
-	}
-
 	public static boolean isTravellersArmorAndBroken(ItemStack stack) {
 		return stack.has(TFDataComponents.IS_TRAVELLERS_GEAR) && stack.isDamageableItem() && stack.getMaxDamage() - 1 <= stack.getDamageValue();
 	}
@@ -182,61 +166,58 @@ public class TravellersArmorItem extends Item implements TravellersModifiable {
 			super(TFModelLayers.TRAVELLERS_ARMOR_HELMET, TFModelLayers.TRAVELLERS_ARMOR_CHEST_GLOVES, TFModelLayers.TRAVELLERS_ARMOR_CHEST_GLOVES_SLIM, TFModelLayers.TRAVELLERS_ARMOR_LEGGINGS, TFModelLayers.TRAVELLERS_ARMOR_BOOTS);
 		}
 
-		//TODO I dont know how to check the entity for this anymore.
-		//we dont even have access to the renderstate which wouldve been a way around it, but alas
-		@Nullable
 		@Override
-		public Identifier getArmorTexture(ItemStack stack, EquipmentClientInfo.LayerType type, EquipmentClientInfo.Layer layer, Identifier def) {
-			return type != EquipmentClientInfo.LayerType.HUMANOID_LEGGINGS && entity.getData(TFDataAttachments.IS_USING_GOGGLES_ZOOM_MODIFIER) ?
-				TFMain.prefix("textures/models/armor/travellers_layer_1_down.png") :
-				super.getArmorTexture(stack, type, layer, def);
-		}
+		public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, net.minecraft.client.renderer.SubmitNodeCollector collector, ItemStack stack, net.minecraft.client.renderer.entity.state.HumanoidRenderState state, EquipmentSlot slot, int light, net.minecraft.client.model.HumanoidModel<net.minecraft.client.renderer.entity.state.HumanoidRenderState> contextModel) {
+			if (!stack.has(DataComponents.EQUIPPABLE))
+				return;
 
-		@Override
-		public Model<?> getHumanoidArmorModel(ItemStack stack, EquipmentClientInfo.LayerType layerType, Model model) {
-			if (stack.has(DataComponents.EQUIPPABLE)) {
-				EquipmentSlot slot = stack.get(DataComponents.EQUIPPABLE).slot();
-				ModelPart root = switch (slot) {
-					case CHEST -> {
-						ModelPart chestLayer = this.getModelPart(this.isModelSlim(model) ? TFModelLayers.TRAVELLERS_ARMOR_CHEST_GLOVES_SLIM : TFModelLayers.TRAVELLERS_ARMOR_CHEST_GLOVES);
-						chestLayer.getAllParts().forEach(part -> part.skipDraw = true);
-						boolean hasChestplate = stack.has(TFDataComponents.TRAVELLERS_HAS_CHESTPLATE);
-						boolean hasGloves = stack.has(TFDataComponents.TRAVELLERS_HAS_GLOVES);
-						chestLayer.getChild("body").skipDraw = !hasChestplate;
-						chestLayer.getChild("left_arm").skipDraw = !hasGloves;
-						chestLayer.getChild("right_arm").skipDraw = !hasGloves;
-
-						yield chestLayer;
-					}
-					case LEGS -> {
-						ModelPart leggingsLayer = this.getModelPart(TFModelLayers.TRAVELLERS_ARMOR_LEGGINGS);
-						leggingsLayer.getAllParts().forEach(part -> part.skipDraw = true);
-						boolean hasWings = stack.has(TFDataComponents.TRAVELLERS_HAS_WINGS);
-						boolean hasBelt = stack.has(TFDataComponents.TRAVELLERS_HAS_BELT) || TravellersModifiersManager.hasTravellersModifier(Minecraft.getInstance().level.registryAccess(), stack, TravellersModifiersManager.SWAP_HOTBAR_MODIFIER);
-
-						TravellersWingsModel.skipBelt(leggingsLayer, !hasBelt);
-						TravellersWingsModel.skipWings(leggingsLayer, !hasWings);
-
-						yield leggingsLayer;
-					}
-					case FEET -> this.getModelPart(TFModelLayers.TRAVELLERS_ARMOR_BOOTS);
-					default -> null;
-				};
-
-
-				if (slot == EquipmentSlot.LEGS) {
-					return new TravellersWingsModel(root);
-				} else if (root != null) {
-					return new TFArmorModel(root);
+			EquipmentSlot eqSlot = stack.get(DataComponents.EQUIPPABLE).slot();
+			ModelPart root = switch (eqSlot) {
+				case CHEST -> {
+					ModelPart chestLayer = this.getModelPart(this.isModelSlim(contextModel) ? TFModelLayers.TRAVELLERS_ARMOR_CHEST_GLOVES_SLIM : TFModelLayers.TRAVELLERS_ARMOR_CHEST_GLOVES);
+					chestLayer.getAllParts().forEach(part -> part.skipDraw = true);
+					boolean hasChestplate = stack.has(TFDataComponents.TRAVELLERS_HAS_CHESTPLATE);
+					boolean hasGloves = stack.has(TFDataComponents.TRAVELLERS_HAS_GLOVES);
+					chestLayer.getChild("body").skipDraw = !hasChestplate;
+					chestLayer.getChild("left_arm").skipDraw = !hasGloves;
+					chestLayer.getChild("right_arm").skipDraw = !hasGloves;
+					yield chestLayer;
 				}
+				case LEGS -> {
+					ModelPart leggingsLayer = this.getModelPart(TFModelLayers.TRAVELLERS_ARMOR_LEGGINGS);
+					leggingsLayer.getAllParts().forEach(part -> part.skipDraw = true);
+					boolean hasWings = stack.has(TFDataComponents.TRAVELLERS_HAS_WINGS);
+					boolean hasBelt = stack.has(TFDataComponents.TRAVELLERS_HAS_BELT) || TravellersModifiersManager.hasTravellersModifier(Minecraft.getInstance().level.registryAccess(), stack, TravellersModifiersManager.SWAP_HOTBAR_MODIFIER);
+					TravellersWingsModel.skipBelt(leggingsLayer, !hasBelt);
+					TravellersWingsModel.skipWings(leggingsLayer, !hasWings);
+					yield leggingsLayer;
+				}
+				case FEET -> this.getModelPart(TFModelLayers.TRAVELLERS_ARMOR_BOOTS);
+				default -> null;
+			};
+
+			Model armorModel;
+			if (eqSlot == EquipmentSlot.LEGS && root != null) {
+				armorModel = new TravellersWingsModel(root);
+			} else if (root != null) {
+				armorModel = new TFArmorModel(root);
+			} else {
+				return;
 			}
-			return super.getHumanoidArmorModel(stack, layerType, model);
+
+			// TODO [Fabric] the zoom "down" texture switch and the live wings animation need
+			// the entity/wings data piped into the render state (extract batch).
+			Identifier texture = textureFor(stack, eqSlot);
+			collector.submitModel(armorModel, state, poseStack, armorModel.renderType(texture), light, net.minecraft.client.renderer.texture.OverlayTexture.NO_OVERLAY, 0xffffffff, null);
 		}
 
-		@Override
-		public void setupModelAnimations(LivingEntity livingEntity, ItemStack itemStack, EquipmentSlot equipmentSlot, Model model, float limbSwing, float limbSwingAmount, float partialTick, float ageInTicks, float netHeadYaw, float headPitch) {
-			if (model instanceof TravellersWingsModel wingsModel)
-				wingsModel.setupModelAnimations(livingEntity, ageInTicks);
+		private static Identifier textureFor(ItemStack stack, EquipmentSlot slot) {
+			return switch (slot) {
+				case CHEST -> TFMain.prefix("textures/models/armor/travellers_layer_1_gloves.png");
+				case LEGS -> TFMain.prefix("textures/models/armor/travellers_layer_2.png");
+				case FEET -> TFMain.prefix("textures/models/armor/travellers_layer_1.png");
+				default -> TFMain.prefix("textures/models/armor/travellers_layer_1.png");
+			};
 		}
 
 		private boolean isModelSlim(Model<?> model) {
@@ -246,6 +227,6 @@ public class TravellersArmorItem extends Item implements TravellersModifiable {
 	}
 
 	public boolean makesPiglinsNeutral(ItemStack stack, LivingEntity wearer) {
-		return this == TFItems.TRAVELLERS_GOGGLES.get() || stack.has(TFDataComponents.TRAVELLERS_HAS_WINGS);
+		return this == TFItems.TRAVELLERS_GOGGLES || stack.has(TFDataComponents.TRAVELLERS_HAS_WINGS);
 	}
 }


### PR DESCRIPTION
- ArmorRender and TFSimpleArmorRenderer now implement Fabric's ArmorRenderer (render) instead of NeoForge's IClientItemExtensions; models are baked from TFModelLayers and submitted via submitModel, with the texture derived from Equippable#assetId
- TFArmorRenderer no longer depends on NeoForge's IClientItemExtensions or Lazy; it implements ArmorRenderer and bakes layers directly
- TravellersWingsModel uses HumanoidRenderState; the live wings animation and zoom down texture switch still need the entity/wings data piped into the render state during extract (left as TODO)
- ConcatenatedListView is carminite's, TooltipFlag#hasShiftDown became isAdvanced, and the removed Item#isPrimaryItemFor/supportsEnchantment/ canWalkOnPowderedSnow overrides are dropped