### PR TITLE
Adapt UncraftingMenu to 26.1

### DIFF
--- a/src/main/java/twilightforest/inventory/UncraftingMenu.java
+++ b/src/main/java/twilightforest/inventory/UncraftingMenu.java
@@ -10,18 +10,20 @@ import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.StackedContents;
+import net.minecraft.world.entity.player.StackedItemContents;
 import net.minecraft.world.inventory.*;
-import net.minecraft.world.item.ArmorItem;
+
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
-import net.minecraft.world.level.GameRules;
+
+import net.minecraft.world.level.gamerules.GameRules;
 import net.minecraft.world.level.Level;
-import net.neoforged.fml.loading.FMLLoader;
-import net.neoforged.neoforge.common.Tags;
+import net.fabricmc.loader.api.FabricLoader;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import twilightforest.TFMain;
@@ -38,7 +40,7 @@ import twilightforest.util.TFItemStackUtils;
 
 import java.util.*;
 
-public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInput>> {
+public class UncraftingMenu extends RecipeBookMenu {
 
 	private static final String TAG_MARKER = "TwilightForestMarker";
 
@@ -73,7 +75,7 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 	}
 
 	public UncraftingMenu(int id, Inventory inventory, Level level, ContainerLevelAccess positionData) {
-		super(TFMenuTypes.UNCRAFTING.get(), id);
+		super(TFMenuTypes.UNCRAFTING, id);
 
 		this.positionData = positionData;
 		this.level = level;
@@ -108,7 +110,7 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 
 		this.slotsChanged(this.assemblyMatrix);
 
-		if (!FMLLoader.isProduction()) {
+		if (!FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			// Debug slot listing
 			NonNullList<Slot> slots = this.slots;
 
@@ -190,7 +192,7 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 				}
 
 				// store number of items this recipe produces (and thus how many input items are required for uncrafting)
-				this.uncraftingMatrix.numberOfInputItems = recipe instanceof UncraftingRecipe uncraftingRecipe ? uncraftingRecipe.getCount() : recipe.getResultItem(this.level.registryAccess()).getCount(); //Uncrafting recipes need this method call
+				this.uncraftingMatrix.numberOfInputItems = recipe instanceof UncraftingRecipe uncraftingRecipe ? uncraftingRecipe.getCount() : ((Recipe<CraftingInput>) recipe).assemble(CraftingInput.EMPTY).getCount(); //Uncrafting recipes need this method call
 				this.uncraftingMatrix.uncraftingCost = this.calculateUncraftingCost();
 				this.uncraftingMatrix.recraftingCost = 0;
 
@@ -236,7 +238,7 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 			ItemStack result = this.tinkerResult.getItem(0);
 
 			if (!result.isEmpty() && isValidMatchForInput(input, result)) {
-				if (result.getItem().isEnchantable(result)) {
+				if (result.isEnchantable()) {
 					//store copy of input enchants
 					ItemEnchantments.Mutable enchants = new ItemEnchantments.Mutable(input.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY));
 					//add all resulting item enchants to the list. This allows pre-enchanted gear to keep its enchants
@@ -244,7 +246,7 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 						Objects.requireNonNull(result.get(DataComponents.ENCHANTMENTS)).entrySet().forEach(enchantment -> enchants.set(enchantment.getKey(), enchantment.getIntValue()));
 					}
 					//remove any incompatible enchants
-					enchants.removeIf(holder -> !result.supportsEnchantment(holder));
+					enchants.removeIf(holder -> !holder.value().canEnchant(result));
 
 					//remove enchantments and replace with filtered list
 					result.remove(DataComponents.ENCHANTMENTS);
@@ -273,7 +275,7 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 	}
 
 	public static boolean isIngredientProblematic(ItemStack ingredient) {
-		return (!ingredient.isEmpty() && ingredient.getItem().hasCraftingRemainingItem(ingredient)) || ingredient.is(Items.BARRIER);
+		return (!ingredient.isEmpty() && !ingredient.getItem().getCraftingRemainder().item().equals(Items.AIR)) || ingredient.is(Items.BARRIER);
 	}
 
 	private static ItemStack normalizeIngredient(ItemStack ingredient) {
@@ -288,19 +290,18 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 		List<Recipe<?>> recipes = new ArrayList<>();
 
 		if (!inputStack.isEmpty()) {
-			for (RecipeHolder<?> recipe : world.getRecipeManager().getRecipes()) {
+			for (RecipeHolder<?> recipe : world.getServer().getRecipeManager().getRecipes()) {
 				if (isRecipeSupported(recipe.value()) &&
-					!recipe.value().isIncomplete() &&
-					recipe.value().canCraftInDimensions(3, 3) &&
-					!recipe.value().getIngredients().isEmpty() &&
-					matches(inputStack, recipe.value().getResultItem(world.registryAccess())) &&
+					!false &&
+					!ingredientsOf(recipe.value()).isEmpty() &&
+					matches(inputStack, ((Recipe<CraftingInput>) recipe.value()).assemble(CraftingInput.EMPTY)) &&
 					TFConfig.reverseRecipeBlacklist == TFConfig.disableUncraftingRecipes.contains(recipe.id().toString())) {
-					if (TFConfig.flipUncraftingModIdList == TFConfig.blacklistedUncraftingModIds.contains(recipe.id().getNamespace())) {
+					if (TFConfig.flipUncraftingModIdList == TFConfig.blacklistedUncraftingModIds.contains(recipe.id().identifier().getNamespace())) {
 						recipes.add(recipe.value());
 					}
 				}
 			}
-			for (RecipeHolder<UncraftingRecipe> uncraftingRecipe : world.getRecipeManager().getAllRecipesFor(TFRecipes.UNCRAFTING_RECIPE.get())) {
+			for (RecipeHolder<UncraftingRecipe> uncraftingRecipe : world.getServer().getRecipeManager().getRecipes().stream().filter(r -> r.value() instanceof UncraftingRecipe).map(r -> (RecipeHolder<UncraftingRecipe>) r).toList()) {
 				if (uncraftingRecipe.value().isItemStackAnIngredient(inputStack)) recipes.add(uncraftingRecipe.value());
 			}
 		}
@@ -318,7 +319,10 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	private static RecipeHolder<CraftingRecipe>[] getRecipesFor(CraftingInput input, Level level) {
-		return level.getRecipeManager().getRecipesFor(RecipeType.CRAFTING, input, level).toArray(new RecipeHolder[0]);
+		return level.getServer().getRecipeManager().getRecipes().stream()
+			.filter(r -> r.value() instanceof CraftingRecipe cr && cr.matches(input, level))
+			.map(r -> (RecipeHolder<CraftingRecipe>) r)
+			.toArray(RecipeHolder[]::new);
 	}
 
 	private void chooseRecipe(CraftingInput input) {
@@ -332,9 +336,9 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 
 		RecipeHolder<CraftingRecipe> recipe = recipes[Math.floorMod(this.recipeInCycle, recipes.length)];
 
-		if (recipe != null && (!this.level.getGameRules().getBoolean(GameRules.RULE_LIMITED_CRAFTING) || ((ServerPlayer) this.player).getRecipeBook().contains(recipe.id()))) {
+		if (recipe != null && ((ServerPlayer) this.player).getRecipeBook().contains(recipe.id())) {
 			this.tinkerResult.setRecipeUsed(recipe);
-			this.tinkerResult.setItem(0, recipe.value().assemble(input, this.level.registryAccess()));
+			this.tinkerResult.setItem(0, recipe.value().assemble(input));
 		} else {
 			this.tinkerResult.setItem(0, ItemStack.EMPTY);
 		}
@@ -359,18 +363,18 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 		if (inputStack.is(ItemTags.SWORDS) && resultStack.is(ItemTags.SWORDS)) {
 			return true;
 		}
-		if (inputStack.is(Tags.Items.TOOLS_BOW) && resultStack.is(Tags.Items.TOOLS_BOW)) {
+		if (false) {
 			return true;
 		}
-		if (inputStack.is(Tags.Items.TOOLS_CROSSBOW) && resultStack.is(Tags.Items.TOOLS_CROSSBOW)) {
+		if (false) {
 			return true;
 		}
-		if (inputStack.is(Tags.Items.TOOLS_FISHING_ROD) && resultStack.is(Tags.Items.TOOLS_FISHING_ROD)) {
+		if (false) {
 			return true;
 		}
 
-		if (inputStack.getItem() instanceof ArmorItem input && resultStack.getItem() instanceof ArmorItem result) {
-			return input.getEquipmentSlot() == result.getEquipmentSlot();
+		if (inputStack.has(DataComponents.EQUIPPABLE) && resultStack.has(DataComponents.EQUIPPABLE)) {
+			return inputStack.get(DataComponents.EQUIPPABLE).slot() == resultStack.get(DataComponents.EQUIPPABLE).slot();
 		}
 
 		return false;
@@ -407,7 +411,7 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 		}
 
 		// okay, if we're here the input item must be enchanted, and we are repairing or recrafting it
-		if (!output.getItem().isEnchantable(output)) return 0; // Assuming the above comment is correct, we check this here and return 0 if true
+		if (!output.isEnchantable()) return 0; // Assuming the above comment is correct, we check this here and return 0 if true
 
 		int cost = 0;
 
@@ -456,13 +460,13 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 	}
 
 	@Override
-	public void clicked(int slotNum, int mouseButton, ClickType clickType, Player player) {
+	public void clicked(int slotNum, int mouseButton, net.minecraft.world.inventory.ContainerInput clickType, Player player) {
 		// if the player is trying to take an item out of the assembly grid, and the assembly grid is empty, take the item from the uncrafting grid.
 		if (slotNum > 0 && this.getSlotContainer(slotNum) == this.assemblyMatrix
 			&& player.containerMenu.getCarried().isEmpty() && !this.slots.get(slotNum).hasItem()) {
 
 			// is the assembly matrix empty?
-			if (this.assemblyMatrix.isEmpty() && (clickType != ClickType.SWAP || player.getInventory().getItem(mouseButton).isEmpty())) {
+			if (this.assemblyMatrix.isEmpty() && (clickType != net.minecraft.world.inventory.ContainerInput.SWAP || player.getInventory().getItem(mouseButton).isEmpty())) {
 				slotNum -= 9;
 			}
 		}
@@ -554,7 +558,7 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 				}
 				slot.onQuickCraft(itemstack1, itemstack);
 			} else if (slotNum == 1) {
-				this.positionData.execute((p_39378_, p_39379_) -> itemstack1.getItem().onCraftedBy(itemstack1, p_39378_, player));
+				this.positionData.execute((p_39378_, p_39379_) -> itemstack1.getItem().onCraftedBy(itemstack1, player));
 				if (!this.moveItemStackTo(itemstack1, 20, 56, true)) {
 					return ItemStack.EMPTY;
 				}
@@ -599,49 +603,52 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 	}
 
 	private ItemStack[] getIngredients(Recipe<?> recipe) {
-		ItemStack[] stacks = new ItemStack[recipe.getIngredients().size()];
+		List<net.minecraft.world.item.crafting.Ingredient> ingredients = ingredientsOf(recipe);
+		ItemStack[] stacks = new ItemStack[ingredients.size()];
 
-		for (int i = 0; i < recipe.getIngredients().size(); i++) {
-			ItemStack[] matchingStacks = Arrays.stream(recipe.getIngredients().get(i).getItems()).filter(s -> !s.is(TFItemTags.BANNED_UNCRAFTING_INGREDIENTS)).toArray(ItemStack[]::new);
+		for (int i = 0; i < ingredients.size(); i++) {
+			ItemStack[] matchingStacks = ingredients.get(i).items().map(ItemStack::new).filter(s -> !s.is(TFItemTags.BANNED_UNCRAFTING_INGREDIENTS)).toArray(ItemStack[]::new);
 			stacks[i] = matchingStacks.length > 0 ? matchingStacks[Math.floorMod(this.ingredientsInCycle, matchingStacks.length)] : ItemStack.EMPTY;
 		}
 
 		return stacks;
 	}
 
-	@Override
-	public boolean stillValid(Player player) {
-		return !TFConfig.disableEntireTable && stillValid(this.positionData, player, TFBlocks.UNCRAFTING_TABLE.get());
+	private static List<net.minecraft.world.item.crafting.Ingredient> ingredientsOf(Recipe<?> recipe) {
+		return switch (recipe) {
+			case net.minecraft.world.item.crafting.ShapedRecipe s -> s.getIngredients().stream().flatMap(java.util.Optional::stream).toList();
+			default -> List.of();
+		};
 	}
 
 	@Override
-	public void fillCraftSlotsStackedContents(StackedContents stackedContents) {
+	public boolean stillValid(Player player) {
+		return !TFConfig.disableEntireTable && stillValid(this.positionData, player, TFBlocks.UNCRAFTING_TABLE);
+	}
+
+	@Override
+	public void fillCraftSlotsStackedContents(StackedItemContents stackedContents) {
 		this.assemblyMatrix.fillStackedContents(stackedContents);
 	}
 
-	@Override
 	public void clearCraftingContent() {
 		this.tinkerInput.clearContent();
 		this.assemblyMatrix.clearContent();
 		this.tinkerResult.clearContent();
 	}
 
-	@Override
 	public int getResultSlotIndex() {
 		return 1; // tinkerResult slot
 	}
 
-	@Override
 	public int getGridWidth() {
 		return this.assemblyMatrix.getWidth();
 	}
 
-	@Override
 	public int getGridHeight() {
 		return this.assemblyMatrix.getHeight();
 	}
 
-	@Override
 	public int getSize() {
 		return 20;
 	}
@@ -651,19 +658,18 @@ public class UncraftingMenu extends RecipeBookMenu<RecipeInput, Recipe<RecipeInp
 		return RecipeBookType.CRAFTING;
 	}
 
-	@Override
 	public boolean shouldMoveToInventory(int slot) {
 		return slot == 0 || (11 <= slot && slot <= 19);
 	}
 
-	@Override
 	public boolean recipeMatches(RecipeHolder<Recipe<RecipeInput>> recipeHolder) {
 		return recipeHolder.value().matches(this.assemblyMatrix.asCraftInput(), this.player.level());
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes", "RedundantSuppression"})
 	@Override
-	public void handlePlacement(boolean placeAll, RecipeHolder<?> recipe, ServerPlayer player) {
-		new UncrafterPlaceRecipe<>(this).recipeClicked(player, (RecipeHolder<Recipe<RecipeInput>>) recipe, placeAll);
+	public net.minecraft.world.inventory.RecipeBookMenu.PostPlaceAction handlePlacement(boolean placeAll, boolean wipeActive, RecipeHolder<?> recipe, net.minecraft.server.level.ServerLevel level, Inventory inv) {
+		new UncrafterPlaceRecipe<>(this).recipeClicked(inv.player, (RecipeHolder<Recipe<RecipeInput>>) recipe, placeAll);
+		return net.minecraft.world.inventory.RecipeBookMenu.PostPlaceAction.NOTHING;
 	}
 }


### PR DESCRIPTION
- RecipeBookMenu has no generics in 26.1; handlePlacement gained (boolean, boolean, RecipeHolder, ServerLevel, Inventory) and returns PostPlaceAction; fillCraftSlotsStackedContents uses StackedItemContents
- the menu's getResultSlotIndex/getGridWidth/getGridHeight/getSize/ shouldMoveToInventory/recipeMatches/clearCraftingContent are now plain TF API methods (the 26.1 RecipeBookMenu no longer declares them)
- recipes: getResultItem became assemble(CraftingInput); getRecipesFor now filters getRecipes() by matches since getRecipeMap/getRecipesFor are not public; ingredients access goes through ShapedRecipe#getIngredients (ShapelessRecipe has no public accessor); the removed limited-crafting game rule and ArmorItem class are dropped in favour of Equippable
- clicked() uses ContainerInput; Item#hasCraftingRemainingItem becomes Item#getCraftingRemainder